### PR TITLE
Upload to PyPi on Release

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,9 +7,34 @@ on:
   [push, pull_request]
 
 jobs:
-  build:
+  pytest:
 
     runs-on: ubuntu-latest
+    if: always()
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Test with pytest
+      run: |
+        pip install pytest
+        pytest
+
+
+  flake8:
+
+    runs-on: ubuntu-latest
+    if: always()
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
@@ -28,11 +53,27 @@ jobs:
       run: |
         pip install flake8
         flake8
+
+
+  black:
+
+    runs-on: ubuntu-latest
+    if: always()
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
     - name: Check formatting with black
       run: |
         pip install black
         black --check .
-    - name: Test with pytest
-      run: |
-        pip install pytest
-        pytest

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -1,0 +1,102 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# Also run all tests, and check they pass before uploading
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  pytest:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Test with pytest
+      run: |
+        pip install pytest
+        pytest
+
+
+  flake8:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        flake8
+
+
+  black:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Check formatting with black
+      run: |
+        pip install black
+        black --check .
+
+
+  deploy:
+
+    runs-on: ubuntu-latest
+    needs: [pytest, flake8, black]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/doc/developer/RELEASE_HOWTO.md
+++ b/doc/developer/RELEASE_HOWTO.md
@@ -1,0 +1,10 @@
+Release process
+---------------
+
+To make a release fo hypnotoad and upload to PyPi:
+1. merge one or more PRs to `master`
+2. pick the new version number, e.g. 0.1.2, for the next release (bumping
+   major, minor, or patch version according to semantic versioning)
+3. Go to the 'releases' tab and click the 'Draft new release' button - name the
+   new release according to 2., e.g. 0.1.2 with no prefix
+4. The release will automatically upload hypnotoad2 to PyPi

--- a/doc/developer/RELEASE_HOWTO.md
+++ b/doc/developer/RELEASE_HOWTO.md
@@ -1,7 +1,7 @@
 Release process
 ---------------
 
-To make a release fo hypnotoad and upload to PyPi:
+To make a release for hypnotoad and upload to PyPi:
 1. merge one or more PRs to `master`
 2. pick the new version number, e.g. 0.1.2, for the next release (bumping
    major, minor, or patch version according to semantic versioning)


### PR DESCRIPTION
Two updates to Github Actions:
* push/PR tests run `pytest`, `flake8` and `black` jobs separately, and also keep running even if other jobs fail
* new action run when a Release is created, runs all tests and then if they all pass deploys to PyPi