### PR TITLE
Catch errors in HypnotoadGui.run()

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -2,6 +2,16 @@ What's new
 ==========
 
 
+0.1.1 (unreleased)
+------------------
+
+### New Features
+
+- Catch errors in HypnotoadGui.run(), allows changing settings and pressing Run
+  button again if there was an error in grid generation (#24)\
+  By [John Omotani](https://github.com/johnomotani)
+
+
 0.1.0 (24th April 2020)
 -----------------------
 

--- a/hypnotoad/cases/tokamak.py
+++ b/hypnotoad/cases/tokamak.py
@@ -68,6 +68,11 @@ class TokamakEquilibrium(Equilibrium):
         psi_sol_inner=None,  # Default: psinorm_sol_inner
         psi_pf_lower=None,  # Default: psinorm_pf_lower
         psi_pf_upper=None,  # Default: psinorm_pf_upper
+        #
+        # Tolerance for positioning points that should be at X-point, but need to be
+        # slightly displaced from the null so code can follow Grad(psi).
+        # Number between 0. and 1.
+        xpoint_offset=0.5,
     ).push(
         Options(
             # These are HypnotoadOptions
@@ -1179,7 +1184,9 @@ class TokamakEquilibrium(Equilibrium):
             ]
 
             # Add points to the beginning and end near (but not at) the X-points
-            diff = 0.5
+            diff = self.user_options.xpoint_offset
+            if diff < 0.0 or diff > 1.0:
+                raise ValueError(f"xpoint_offset={diff} should be between 0 and 1.")
 
             region["points"] = (
                 [(1.0 - diff) * start_x + diff * points[0]]

--- a/hypnotoad/cases/tokamak.py
+++ b/hypnotoad/cases/tokamak.py
@@ -236,6 +236,9 @@ class TokamakEquilibrium(Equilibrium):
 
         super().__init__(**kwargs)
 
+        # Print the table of options
+        print(optionsTableString(self.user_options, self.default_options))
+
         if make_regions:
             # Create self.regions
             self.makeRegions()
@@ -469,9 +472,6 @@ class TokamakEquilibrium(Equilibrium):
             "poloidal_spacing_delta_psi",
             np.abs((self.user_options.psi_core - self.user_options.psi_sol) / 20.0),
         )
-
-        # Print the table of options
-        print(optionsTableString(self.user_options, self.default_options))
 
         # Filter out the X-points not in range.
         # Keep only those with normalised psi < psinorm_sol

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -328,7 +328,17 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.read_geqdsk()
 
         self.statusbar.showMessage("Running...")
-        self.mesh = BoutMesh(self.eq)
+        try:
+            self.mesh = BoutMesh(self.eq)
+        except (ValueError, SolutionError):
+            self.statusbar.showMessage(
+                "Error in grid generation, change settings and run again!"
+            )
+            self.statusbar.setStyleSheet(
+                f"QLineEdit {{ background-color: {COLOURS['red']} }}"
+            )
+            return
+
         self.mesh.calculateRZ()
         self.statusbar.showMessage("Done!", 2000)
 

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -323,6 +323,10 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
             )
             return
 
+        # Call read_geqdsk to recreate self.eq object in case any settings needed in
+        # __init__ have been changed
+        self.read_geqdsk()
+
         self.statusbar.showMessage("Running...")
         self.mesh = BoutMesh(self.eq)
         self.mesh.calculateRZ()

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -22,6 +22,7 @@ from .hypnotoad_mainWindow import Ui_Hypnotoad
 from .matplotlib_widget import MatplotlibWidget
 from ..cases import tokamak
 from ..core.mesh import BoutMesh
+from ..core.equilibrium import SolutionError
 from ..__init__ import __version__
 
 


### PR DESCRIPTION
Allows settings to be changed before trying `Run` again if there is an error.

Also a couple of very small tidy up changes:
- print options from `TokamakEquilibrium.__init__()` instead of `TokamakEquilibrium.makeRegions()`
- add setting to choose the displacement of grid points that should be at the X-point

- [x] Updated `doc/whats-new.md` with a summary of the changes
