### PR TITLE
Gui options

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,6 +8,7 @@ ignore = (
 )
 exclude =
     hypnotoad/gui/hypnotoad_mainWindow.py,
+    hypnotoad/gui/hypnotoad_preferences.py,
     hypnotoad/gui/__init__.py
     hypnotoad/__version__.py
     versioneer.py

--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -18,9 +18,20 @@ What's new
   By [John Omotani](https://github.com/johnomotani)
 
 
+### Bug fixes
+
+- If an empty string is passed to a value in the options table of the GUI,
+  resets the option to its default value. Previously this caused a crash (#25)\
+  By [John Omotani](https://github.com/johnomotani)
+
+
 ### Internal changes
 
-- Use Options objects to store settings in HypnotoadGui (#25)\
+- Make options table keys in HypnotoadGui immutable. Also makes the use of
+  Options object in Equilibrium/TokamakEquilibrium more consistent by ensuring
+  self.user_options has only been delegated once from
+  TokamakEquilibrium.default_options (i.e. the push() method has only been used
+  once, otherwise update() or set() are called) (#25)\
   By [John Omotani](https://github.com/johnomotani)
 
 

--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -7,6 +7,9 @@ What's new
 
 ### New Features
 
+- Add preferences dialog to GUI (#25)\
+  By [Peter Hill](https://github.com/ZedThree)
+
 - Catch errors in HypnotoadGui.run(), allows changing settings and pressing Run
   button again if there was an error in grid generation (#24)\
   By [John Omotani](https://github.com/johnomotani)

--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -2,6 +2,18 @@ What's new
 ==========
 
 
+0.1.1 (unreleased)
+------------------
+
+### New Features
+
+
+### Internal changes
+
+- Use Options objects to store settings in HypnotoadGui (#25)\
+  By [John Omotani](https://github.com/johnomotani)
+
+
 0.1.0 (24th April 2020)
 -----------------------
 

--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -8,7 +8,8 @@ What's new
 ### New Features
 
 - Add preferences dialog to GUI (#25)\
-  By [Peter Hill](https://github.com/ZedThree)
+  By [Peter Hill](https://github.com/ZedThree) and [John
+  Omotani](https://github.com/johnomotani)
 
 - Catch errors in HypnotoadGui.run(), allows changing settings and pressing Run
   button again if there was an error in grid generation (#24)\

--- a/hypnotoad/cases/tokamak.py
+++ b/hypnotoad/cases/tokamak.py
@@ -233,9 +233,8 @@ class TokamakEquilibrium(Equilibrium):
 
         # Take the default settings, then the options keyword, then
         # any additional keyword arguments
-        self.user_options = TokamakEquilibrium.default_options.push(options).push(
-            kwargs
-        )
+        self.user_options = TokamakEquilibrium.default_options.push(options)
+        self.user_options.update(kwargs)
 
         self.equilibOptions = {}
 
@@ -388,7 +387,7 @@ class TokamakEquilibrium(Equilibrium):
         assert self.psi_axis is not None
 
         # Options can be passed in here to customise the regions created
-        self.user_options = self.user_options.push(kwargs)
+        self.user_options.update(kwargs)
 
         self.updateOptions()
 

--- a/hypnotoad/cases/tokamak.py
+++ b/hypnotoad/cases/tokamak.py
@@ -390,6 +390,33 @@ class TokamakEquilibrium(Equilibrium):
         # Options can be passed in here to customise the regions created
         self.user_options = self.user_options.push(kwargs)
 
+        self.updateOptions()
+
+        # Check that there are only one or two left
+        assert 0 < len(self.x_points) <= 2
+
+        if len(self.x_points) == 1:
+            # Generate the specifications for a lower or upper single null
+            leg_regions, core_regions, segments, connections = self.describeSingleNull()
+        else:
+            # Specifications for a double null (connected or disconnected)
+            leg_regions, core_regions, segments, connections = self.describeDoubleNull()
+
+        # Create a new dictionary, which will contain all regions
+        # including core and legs
+        all_regions = leg_regions.copy()
+        all_regions.update(self.coreRegionToRegion(core_regions))
+
+        # Create the regions in an OrderedDict, assign to self.regions
+        self.regions = self.createRegionObjects(all_regions, segments)
+
+        # Make the connections between regions
+        for connection in connections:
+            self.makeConnection(*connection)
+
+    def updateOptions(self):
+        super().updateOptions()
+
         # Radial grid cells in PF regions
         setDefault(self.user_options, "nx_pf", self.user_options.nx_core)
 
@@ -487,28 +514,6 @@ class TokamakEquilibrium(Equilibrium):
                 if psi_to_psinorm(psi) < self.user_options.psinorm_sol
             )
         )
-
-        # Check that there are only one or two left
-        assert 0 < len(self.x_points) <= 2
-
-        if len(self.x_points) == 1:
-            # Generate the specifications for a lower or upper single null
-            leg_regions, core_regions, segments, connections = self.describeSingleNull()
-        else:
-            # Specifications for a double null (connected or disconnected)
-            leg_regions, core_regions, segments, connections = self.describeDoubleNull()
-
-        # Create a new dictionary, which will contain all regions
-        # including core and legs
-        all_regions = leg_regions.copy()
-        all_regions.update(self.coreRegionToRegion(core_regions))
-
-        # Create the regions in an OrderedDict, assign to self.regions
-        self.regions = self.createRegionObjects(all_regions, segments)
-
-        # Make the connections between regions
-        for connection in connections:
-            self.makeConnection(*connection)
 
     def describeSingleNull(self):
         """

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -1534,7 +1534,7 @@ class EquilibriumRegion(PsiContour):
         self.user_options = user_options
 
         # Set up options for this object: poloidal spacing options need setting
-        self.options = options.copy()
+        self.options = options.push({})
 
         # Set object-specific options
         assert self.options.nx is not None, "nx must be set"
@@ -2636,6 +2636,12 @@ class Equilibrium:
         FineContour.options = FineContour.options.push(dict(self.user_options))
 
         # Set some default options
+        self.updateOptions()
+
+    def updateOptions(self):
+        """
+        Set default values from user_options
+        """
         setDefault(
             self.user_options,
             "nonorthogonal_xpoint_poloidal_spacing_range_inner",
@@ -2656,6 +2662,10 @@ class Equilibrium:
             "nonorthogonal_target_poloidal_spacing_range_outer",
             self.user_options.nonorthogonal_target_poloidal_spacing_range,
         )
+
+        if hasattr(self, "regions"):
+            for region in self.regions.values():
+                region.setupOptions(force=False)
 
     def makeConnection(self, lowerRegion, lowerSegment, upperRegion, upperSegment):
         """

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -2636,7 +2636,7 @@ class Equilibrium:
         FineContour.options = FineContour.options.push(dict(self.user_options))
 
         # Set some default options
-        self.updateOptions()
+        Equilibrium.updateOptions(self)
 
     def updateOptions(self):
         """

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -35,6 +35,15 @@ COLOURS = {
 }
 
 
+def _table_item_edit_display(item):
+    """Hide the "(default)" marker on table items in the options form
+
+    """
+    default_marker = " (default)"
+    if item.text().endswith(default_marker):
+        item.setText(item.text()[: -len(default_marker)])
+
+
 class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
     """A graphical interface for Hypnotoad
 
@@ -108,6 +117,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.search_bar.setCompleter(self.search_bar_completer)
 
         self.options_form.cellChanged.connect(self.options_form_changed)
+        self.options_form.itemDoubleClicked.connect(_table_item_edit_display)
         self.update_options_form()
 
     def help_about(self):

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -309,15 +309,20 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         try:
             with open(geqdsk_filename, "rt") as f:
                 self.eq = tokamak.read_geqdsk(f, options=dict(self.options))
-            # Use eq object's options so they get updated when we change the options
-            # table
-            self.options = self.eq.user_options
-            self.update_options_form()
         except (ValueError, RuntimeError) as e:
             error_message = QErrorMessage()
             error_message.showMessage(str(e))
             error_message.exec_()
             return
+
+        # Use eq object's options so they get updated when we change the options
+        # table
+        self.options = self.eq.user_options
+        self.update_options_form()
+
+        # Delete mesh if it exists, since we have a new self.eq object
+        if hasattr(self, "mesh"):
+            del self.mesh
 
         self.plot_widget.clear()
         self.eq.plotPotential(ncontours=40, axis=self.plot_widget.axes)

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -431,4 +431,6 @@ class Preferences(QDialog, Ui_Preferences):
             plot_corners=self.plotCornersCheckBox.isChecked(),
         )
 
+        self.parent.plot_grid()
+
         super().accept()

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -4,6 +4,7 @@ GUI for Hypnotoad using Qt
 """
 
 import ast
+import copy
 import options
 import os
 import yaml
@@ -207,7 +208,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
 
         """
 
-        filtered_options = self.options.copy()
+        filtered_options = copy.deepcopy(self.options)
         filtered_defaults = dict(tokamak.TokamakEquilibrium.default_options)
         # Skip options handled specially elsewhere
         del filtered_defaults["_magic"]
@@ -354,7 +355,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
 
         try:
             with open(geqdsk_filename, "rt") as f:
-                self.eq = tokamak.read_geqdsk(f, options=self.options.copy())
+                self.eq = tokamak.read_geqdsk(f, options=copy.deepcopy(self.options))
         except (ValueError, RuntimeError) as e:
             error_message = QErrorMessage()
             error_message.showMessage(str(e))

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -223,6 +223,26 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
             raise ValueError("Not allowed to change option names")
         else:
             key = self.options_form.item(row, 0).text()
+
+            if item.text() == "":
+                # Reset to default
+                # Might be better to just keep the old value if nothing is passed, but
+                # don't know how to get that
+                default_value = tokamak.TokamakEquilibrium.default_options[key]
+                self.options_form.cellChanged.disconnect(self.options_form_changed)
+                self.options_form.setItem(
+                    row, 1, QTableWidgetItem(f"{default_value} (default)")
+                )
+                self.options_form.cellChanged.connect(self.options_form_changed)
+                if key in self.options:
+                    del self.options[key]
+                if hasattr(self, "eq"):
+                    # deleting from this object means self.eq uses the value from
+                    # TokamakEquilibrium.default_options
+                    del self.eq.user_options[key]
+                    self.eq.updateOptions()
+                return
+
             self.options[key] = ast.literal_eval(item.text())
             if hasattr(self, "eq"):
                 self.eq.user_options.update(**self.options)

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -16,10 +16,12 @@ from Qt.QtWidgets import (
     QTableWidgetItem,
     QHeaderView,
     QErrorMessage,
+    QDialog,
 )
 from Qt.QtCore import Qt
 
 from .hypnotoad_mainWindow import Ui_Hypnotoad
+from .hypnotoad_preferences import Ui_Preferences
 from .matplotlib_widget import MatplotlibWidget
 from ..cases import tokamak
 from ..core.mesh import BoutMesh
@@ -83,6 +85,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         set_triggered(self.action_New, self.new_options)
         set_triggered(self.action_Open, self.select_options_file)
         set_triggered(self.action_About, self.help_about)
+        set_triggered(self.action_Preferences, self.open_preferences)
 
         self.action_Quit.triggered.connect(self.close)
 
@@ -111,6 +114,13 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         about_box = QMessageBox(self)
         about_box.setText(about_text)
         about_box.exec_()
+
+    def open_preferences(self):
+        """GUI preferences and settings
+
+        """
+        preferences_window = Preferences(self)
+        preferences_window.exec_()
 
     def revert_options(self):
         """Revert the current options to the loaded file, or defaults if no
@@ -385,3 +395,29 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         )
 
         self.mesh.writeGridfile(filename)
+
+
+class Preferences(QDialog, Ui_Preferences):
+    """Dialog box for editing Hypnotoad preferences
+    """
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.setupUi(self)
+        self.parent = parent
+
+        self.defaultGridFileNameLineEdit.setText(self.parent.gui_options["grid_file"])
+        self.plotXlowCheckBox.setChecked(self.parent.gui_options["plot_xlow"])
+        self.plotYlowCheckBox.setChecked(self.parent.gui_options["plot_ylow"])
+        self.plotCornersCheckBox.setChecked(self.parent.gui_options["plot_corners"])
+
+    def accept(self):
+
+        self.parent.gui_options = options.Options(
+            grid_file=self.defaultGridFileNameLineEdit.text(),
+            plot_xlow=self.plotXlowCheckBox.isChecked(),
+            plot_ylow=self.plotYlowCheckBox.isChecked(),
+            plot_corners=self.plotCornersCheckBox.isChecked(),
+        )
+
+        super().accept()

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -179,6 +179,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         for row, (key, value) in enumerate(sorted(self.options.items())):
             item = QTableWidgetItem(key)
             item.old_key = key
+            item.setFlags(item.flags() & ~Qt.ItemIsEditable)
             self.options_form.setItem(row, 0, item)
             self.options_form.setItem(row, 1, QTableWidgetItem(str(value)))
 
@@ -193,18 +194,9 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
 
         item = self.options_form.item(row, column)
 
-        if row == self.options_form.rowCount() - 1:
-            self.options[item.text()] = None
-            self.options_form.setRowCount(len(self.options) + 1)
-            return
-
         if column == 0:
-            key = item.text()
-            if key == item.old_key:
-                return
-
-            self.options[key] = self.options.pop(item.old_key)
-            item.old_key = key
+            # column 0 is not editable, so this should not be possible
+            raise ValueError("Not allowed to change option names")
         else:
             key = self.options_form.item(row, 0).text()
             self.options[key] = ast.literal_eval(item.text())

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -178,7 +178,11 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.options_form.cellChanged.disconnect(self.options_form_changed)
         self.options_form.setRowCount(len(self.options))
 
-        for row, (key, value) in enumerate(sorted(self.options.items())):
+        filtered_options = dict(self.options)
+        # Skip special keys and options handled specially elsewhere
+        del filtered_options["_magic"]
+
+        for row, (key, value) in enumerate(sorted(filtered_options.items())):
             item = QTableWidgetItem(key)
             item.old_key = key
             item.setFlags(item.flags() & ~Qt.ItemIsEditable)

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -186,13 +186,13 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
 
         """
 
-        self.options_form.setSortingEnabled(False)
-        self.options_form.cellChanged.disconnect(self.options_form_changed)
-        self.options_form.setRowCount(len(self.options))
-
         filtered_options = dict(self.options)
         # Skip special keys and options handled specially elsewhere
         del filtered_options["_magic"]
+
+        self.options_form.setSortingEnabled(False)
+        self.options_form.cellChanged.disconnect(self.options_form_changed)
+        self.options_form.setRowCount(len(filtered_options))
 
         for row, (key, value) in enumerate(sorted(filtered_options.items())):
             item = QTableWidgetItem(key)

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -324,16 +324,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         if hasattr(self, "mesh"):
             del self.mesh
 
-        self.plot_widget.clear()
-        self.eq.plotPotential(ncontours=40, axis=self.plot_widget.axes)
-        self.eq.plotWall(axis=self.plot_widget.axes)
-        for region in self.eq.regions.values():
-            self.plot_widget.axes.plot(
-                [p.R for p in region.points], [p.Z for p in region.points], "-o"
-            )
-
-        self.plot_widget.axes.plot(*self.eq.x_points[0], "rx")
-        self.plot_widget.canvas.draw()
+        self.plot_grid()
 
     def run(self):
         """Run Hypnotoad and generate the grid
@@ -363,16 +354,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.mesh.calculateRZ()
         self.statusbar.showMessage("Done!", 2000)
 
-        self.plot_widget.clear()
-        self.eq.plotPotential(ncontours=40, axis=self.plot_widget.axes)
-        self.eq.plotWall(axis=self.plot_widget.axes)
-        self.mesh.plotPoints(
-            xlow=self.gui_options["plot_xlow"],
-            ylow=self.gui_options["plot_ylow"],
-            corners=self.gui_options["plot_corners"],
-            ax=self.plot_widget.axes,
-        )
-        self.plot_widget.canvas.draw()
+        self.plot_grid()
 
         self.write_grid_button.setEnabled(True)
 
@@ -399,6 +381,31 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         )
 
         self.mesh.writeGridfile(filename)
+
+    def plot_grid(self):
+        self.plot_widget.clear()
+
+        if hasattr(self, "eq"):
+            self.eq.plotPotential(ncontours=40, axis=self.plot_widget.axes)
+            self.eq.plotWall(axis=self.plot_widget.axes)
+
+        if hasattr(self, "mesh"):
+            # mesh exists, so plot the grid points
+            self.mesh.plotPoints(
+                xlow=self.gui_options["plot_xlow"],
+                ylow=self.gui_options["plot_ylow"],
+                corners=self.gui_options["plot_corners"],
+                ax=self.plot_widget.axes,
+            )
+        elif hasattr(self, "eq"):
+            # no mesh, but do have equilibrium, so plot separatrices
+            for region in self.eq.regions.values():
+                self.plot_widget.axes.plot(
+                    [p.R for p in region.points], [p.Z for p in region.points], "-o"
+                )
+            self.plot_widget.axes.plot(*self.eq.x_points[0], "rx")
+
+        self.plot_widget.canvas.draw()
 
 
 class Preferences(QDialog, Ui_Preferences):

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -298,6 +298,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
             self.eq = tokamak.read_geqdsk(f, options=dict(self.options))
         # Use eq object's options so they get updated when we change the options table
         self.options = self.eq.user_options
+        self.update_options_form()
 
         self.plot_widget.clear()
         self.eq.plotPotential(ncontours=40, axis=self.plot_widget.axes)

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -370,7 +370,6 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.plot_widget.canvas.draw()
 
         self.write_grid_button.setEnabled(True)
-        self.mesh.calculateRZ()
 
     def write_grid(self):
         """Write generated mesh to file

--- a/hypnotoad/gui/hypnotoad_mainWindow.py
+++ b/hypnotoad/gui/hypnotoad_mainWindow.py
@@ -111,6 +111,10 @@ class Ui_Hypnotoad(object):
             icon8.addFile(u".", QSize(), QIcon.Normal, QIcon.Off)
 
         self.action_Revert.setIcon(icon8)
+        self.action_Preferences = QAction(Hypnotoad)
+        self.action_Preferences.setObjectName(u"action_Preferences")
+        icon9 = QIcon(QIcon.fromTheme(u"document-properties"))
+        self.action_Preferences.setIcon(icon9)
         self.centralwidget = QWidget(Hypnotoad)
         self.centralwidget.setObjectName(u"centralwidget")
         self.horizontalLayout_2 = QHBoxLayout(self.centralwidget)
@@ -218,6 +222,7 @@ class Ui_Hypnotoad(object):
         self.menu_File.addAction(self.action_Save_as)
         self.menu_File.addAction(self.action_Revert)
         self.menu_File.addSeparator()
+        self.menu_File.addAction(self.action_Preferences)
         self.menu_File.addAction(self.action_Quit)
         self.menu_Help.addAction(self.action_About)
         self.menu_Mesh.addAction(self.action_Run)
@@ -248,6 +253,7 @@ class Ui_Hypnotoad(object):
         self.action_Run.setText(QCoreApplication.translate("Hypnotoad", u"&Run", None))
         self.action_Write_grid.setText(QCoreApplication.translate("Hypnotoad", u"&Write grid", None))
         self.action_Revert.setText(QCoreApplication.translate("Hypnotoad", u"&Revert", None))
+        self.action_Preferences.setText(QCoreApplication.translate("Hypnotoad", u"&Preferences...", None))
         ___qtablewidgetitem = self.options_form.horizontalHeaderItem(0)
         ___qtablewidgetitem.setText(QCoreApplication.translate("Hypnotoad", u"Name", None));
         ___qtablewidgetitem1 = self.options_form.horizontalHeaderItem(1)

--- a/hypnotoad/gui/hypnotoad_mainWindow.ui
+++ b/hypnotoad/gui/hypnotoad_mainWindow.ui
@@ -116,6 +116,7 @@
     <addaction name="action_Save_as"/>
     <addaction name="action_Revert"/>
     <addaction name="separator"/>
+    <addaction name="action_Preferences"/>
     <addaction name="action_Quit"/>
    </widget>
    <widget class="QMenu" name="menu_Help">
@@ -235,6 +236,14 @@
    </property>
    <property name="text">
     <string>&amp;Revert</string>
+   </property>
+  </action>
+  <action name="action_Preferences">
+   <property name="icon">
+    <iconset theme="document-properties"/>
+   </property>
+   <property name="text">
+    <string>&amp;Preferences...</string>
    </property>
   </action>
  </widget>

--- a/hypnotoad/gui/hypnotoad_preferences.py
+++ b/hypnotoad/gui/hypnotoad_preferences.py
@@ -76,6 +76,17 @@ class Ui_Preferences(object):
 
         self.formLayout.setWidget(3, QFormLayout.FieldRole, self.plotCornersCheckBox)
 
+        self.saveFullYamlLabel = QLabel(self.formLayoutWidget)
+        self.saveFullYamlLabel.setObjectName(u"saveFullYamlLabel")
+
+        self.formLayout.setWidget(4, QFormLayout.LabelRole, self.saveFullYamlLabel)
+
+        self.saveFullYamlCheckBox = QCheckBox(self.formLayoutWidget)
+        self.saveFullYamlCheckBox.setObjectName(u"saveFullYamlCheckBox")
+        self.saveFullYamlCheckBox.setChecked(False)
+
+        self.formLayout.setWidget(4, QFormLayout.FieldRole, self.saveFullYamlCheckBox)
+
 
         self.verticalLayout.addWidget(self.frame)
 
@@ -101,5 +112,6 @@ class Ui_Preferences(object):
         self.plotXlowLabel.setText(QCoreApplication.translate("Preferences", u"Plot xlow", None))
         self.plotYlowLabel.setText(QCoreApplication.translate("Preferences", u"Plot ylow", None))
         self.plotCornersLabel.setText(QCoreApplication.translate("Preferences", u"Plot corners", None))
+        self.saveFullYamlLabel.setText(QCoreApplication.translate("Preferences", u"Include options set by\ndefault when saving to YAML", None))
     # retranslateUi
 

--- a/hypnotoad/gui/hypnotoad_preferences.py
+++ b/hypnotoad/gui/hypnotoad_preferences.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'hypnotoad_preferences.ui'
+##
+## Created by: Qt User Interface Compiler version 5.14.2
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from Qt.QtCore import (QCoreApplication, QDate, QDateTime, QMetaObject,
+    QObject, QPoint, QRect, QSize, QTime, QUrl, Qt)
+from Qt.QtGui import (QBrush, QColor, QConicalGradient, QCursor, QFont,
+    QFontDatabase, QIcon, QKeySequence, QLinearGradient, QPalette, QPainter,
+    QPixmap, QRadialGradient)
+from Qt.QtWidgets import *
+
+
+class Ui_Preferences(object):
+    def setupUi(self, Preferences):
+        if not Preferences.objectName():
+            Preferences.setObjectName(u"Preferences")
+        Preferences.resize(400, 300)
+        self.verticalLayout = QVBoxLayout(Preferences)
+        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.frame = QFrame(Preferences)
+        self.frame.setObjectName(u"frame")
+        self.frame.setFrameShape(QFrame.StyledPanel)
+        self.frame.setFrameShadow(QFrame.Raised)
+        self.formLayoutWidget = QWidget(self.frame)
+        self.formLayoutWidget.setObjectName(u"formLayoutWidget")
+        self.formLayoutWidget.setGeometry(QRect(10, 10, 361, 211))
+        self.formLayout = QFormLayout(self.formLayoutWidget)
+        self.formLayout.setObjectName(u"formLayout")
+        self.formLayout.setContentsMargins(0, 0, 0, 0)
+        self.defaultGridFileNameLabel = QLabel(self.formLayoutWidget)
+        self.defaultGridFileNameLabel.setObjectName(u"defaultGridFileNameLabel")
+
+        self.formLayout.setWidget(0, QFormLayout.LabelRole, self.defaultGridFileNameLabel)
+
+        self.defaultGridFileNameLineEdit = QLineEdit(self.formLayoutWidget)
+        self.defaultGridFileNameLineEdit.setObjectName(u"defaultGridFileNameLineEdit")
+
+        self.formLayout.setWidget(0, QFormLayout.FieldRole, self.defaultGridFileNameLineEdit)
+
+        self.plotXlowLabel = QLabel(self.formLayoutWidget)
+        self.plotXlowLabel.setObjectName(u"plotXlowLabel")
+
+        self.formLayout.setWidget(1, QFormLayout.LabelRole, self.plotXlowLabel)
+
+        self.plotXlowCheckBox = QCheckBox(self.formLayoutWidget)
+        self.plotXlowCheckBox.setObjectName(u"plotXlowCheckBox")
+        self.plotXlowCheckBox.setChecked(True)
+
+        self.formLayout.setWidget(1, QFormLayout.FieldRole, self.plotXlowCheckBox)
+
+        self.plotYlowLabel = QLabel(self.formLayoutWidget)
+        self.plotYlowLabel.setObjectName(u"plotYlowLabel")
+
+        self.formLayout.setWidget(2, QFormLayout.LabelRole, self.plotYlowLabel)
+
+        self.plotYlowCheckBox = QCheckBox(self.formLayoutWidget)
+        self.plotYlowCheckBox.setObjectName(u"plotYlowCheckBox")
+        self.plotYlowCheckBox.setChecked(True)
+
+        self.formLayout.setWidget(2, QFormLayout.FieldRole, self.plotYlowCheckBox)
+
+        self.plotCornersLabel = QLabel(self.formLayoutWidget)
+        self.plotCornersLabel.setObjectName(u"plotCornersLabel")
+
+        self.formLayout.setWidget(3, QFormLayout.LabelRole, self.plotCornersLabel)
+
+        self.plotCornersCheckBox = QCheckBox(self.formLayoutWidget)
+        self.plotCornersCheckBox.setObjectName(u"plotCornersCheckBox")
+        self.plotCornersCheckBox.setChecked(True)
+
+        self.formLayout.setWidget(3, QFormLayout.FieldRole, self.plotCornersCheckBox)
+
+
+        self.verticalLayout.addWidget(self.frame)
+
+        self.buttonBox = QDialogButtonBox(Preferences)
+        self.buttonBox.setObjectName(u"buttonBox")
+        self.buttonBox.setOrientation(Qt.Horizontal)
+        self.buttonBox.setStandardButtons(QDialogButtonBox.Cancel|QDialogButtonBox.Ok)
+
+        self.verticalLayout.addWidget(self.buttonBox)
+
+
+        self.retranslateUi(Preferences)
+        self.buttonBox.accepted.connect(Preferences.accept)
+        self.buttonBox.rejected.connect(Preferences.reject)
+
+        QMetaObject.connectSlotsByName(Preferences)
+    # setupUi
+
+    def retranslateUi(self, Preferences):
+        Preferences.setWindowTitle(QCoreApplication.translate("Preferences", u"Hypnotoad Preferences", None))
+        self.defaultGridFileNameLabel.setText(QCoreApplication.translate("Preferences", u"Default grid file name", None))
+        self.defaultGridFileNameLineEdit.setPlaceholderText(QCoreApplication.translate("Preferences", u"bout.grid.nc", None))
+        self.plotXlowLabel.setText(QCoreApplication.translate("Preferences", u"Plot xlow", None))
+        self.plotYlowLabel.setText(QCoreApplication.translate("Preferences", u"Plot ylow", None))
+        self.plotCornersLabel.setText(QCoreApplication.translate("Preferences", u"Plot corners", None))
+    # retranslateUi
+

--- a/hypnotoad/gui/hypnotoad_preferences.ui
+++ b/hypnotoad/gui/hypnotoad_preferences.ui
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Preferences</class>
+ <widget class="QDialog" name="Preferences">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Hypnotoad Preferences</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QFrame" name="frame">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <widget class="QWidget" name="formLayoutWidget">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>10</y>
+        <width>361</width>
+        <height>211</height>
+       </rect>
+      </property>
+      <layout class="QFormLayout" name="formLayout">
+       <item row="0" column="0">
+        <widget class="QLabel" name="defaultGridFileNameLabel">
+         <property name="text">
+          <string>Default grid file name</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLineEdit" name="defaultGridFileNameLineEdit">
+         <property name="placeholderText">
+          <string>bout.grid.nc</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="plotXlowLabel">
+         <property name="text">
+          <string>Plot xlow</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QCheckBox" name="plotXlowCheckBox">
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="plotYlowLabel">
+         <property name="text">
+          <string>Plot ylow</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QCheckBox" name="plotYlowCheckBox">
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="plotCornersLabel">
+         <property name="text">
+          <string>Plot corners</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QCheckBox" name="plotCornersCheckBox">
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Preferences</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Preferences</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/hypnotoad/gui/hypnotoad_preferences.ui
+++ b/hypnotoad/gui/hypnotoad_preferences.ui
@@ -88,6 +88,20 @@
          </property>
         </widget>
        </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="saveFullYamlLabel">
+         <property name="text">
+          <string>Include options set by\ndefault when saving to YAML</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QCheckBox" name="saveFullYamlCheckBox">
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
     </widget>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,5 +4,6 @@ exclude = '''
   hypnotoad/gui/hypnotoad_mainWindow.py
   | versioneer.py
   | hypnotoad/__version__.py
+  | hypnotoad/gui/hypnotoad_preferences.py
 )
 '''


### PR DESCRIPTION
~~Use `Options` objects to store options in `HypnotoadGui`. This means we can directly modify the `user_options` of the `TokamakEquilibrium` object when settings are changed.~~

- [x] Updated `doc/whats-new.md` with a summary of the changes
