### PR TITLE
Tokamak nonorthogonal grids

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -5,7 +5,11 @@ What's new
 0.1.1 (unreleased)
 ------------------
 
-### New Features
+### New features
+
+- Button allowing grid to be regenerated in the gui after nonorthogonal spacing
+  options are changed (#26)\
+  By [John Omotani](https://github.com/johnomotani)
 
 - Options have associated `doc` attributes, visible as tool-tips in the GUI
   (#33)\
@@ -17,13 +21,17 @@ What's new
 
 - Catch errors in HypnotoadGui.run(), allows changing settings and pressing Run
   button again if there was an error in grid generation (#24)\
-  By [John Omotani](https://github.com/johnomotani)
+  By [John Omotani](https://github.com/johnomotani) and [Peter
+  Hill](https://github.com/ZedThree)
 
 - Plot wall in gui window (#23)\
   By [John Omotani](https://github.com/johnomotani)
 
 
 ### Bug fixes
+
+- More robust generation of non-orthogonal grids for tokamak cases (#26)\
+  By [John Omotani](https://github.com/johnomotani)
 
 - If an empty string is passed to a value in the options table of the GUI,
   resets the option to its default value. Previously this caused a crash (#25)\
@@ -50,7 +58,7 @@ What's new
 0.1.0 (24th April 2020)
 -----------------------
 
-### New Features
+### New features
 
 - Github Action to upload hypnotoad to PyPi on release (#19)\
   By [John Omotani](https://github.com/johnomotani)

--- a/hypnotoad/cases/tokamak.py
+++ b/hypnotoad/cases/tokamak.py
@@ -614,7 +614,7 @@ class TokamakEquilibrium(Equilibrium):
         legs = self.findLegs(self.x_points[0])
 
         # Move the first point of each leg slightly away from the X-point
-        diff = 0.1
+        diff = self.user_options.xpoint_offset
         for leg in legs.values():
             leg[0] = diff * leg[1] + (1.0 - diff) * leg[0]
 
@@ -805,7 +805,7 @@ class TokamakEquilibrium(Equilibrium):
         upper_legs = self.findLegs(upper_x_point)
 
         # Move the first point of each leg slightly away from the X-point
-        diff = 0.1
+        diff = self.user_options.xpoint_offset
         for legs in [lower_legs, upper_legs]:
             for leg in legs.values():
                 leg[0] = diff * leg[1] + (1.0 - diff) * leg[0]

--- a/hypnotoad/cases/tokamak.py
+++ b/hypnotoad/cases/tokamak.py
@@ -839,15 +839,7 @@ class TokamakEquilibrium(Equilibrium):
             dpsidi_sep *= self.user_options.psi_spacing_separatrix_multiplier
 
         # Number of points in the inter-separatrix region
-        # This is zero for a connected double null, > 0 for disconnected double null
-        # Limit the number so that at least 2 cells are in the SOL regions
-        nx_inter_sep = min(
-            [
-                int(np.rint(abs((upper_psi - lower_psi) / dpsidi_sep))),
-                self.user_options.nx_sol_outer - 2,
-                self.user_options.nx_sol_inner - 2,
-            ]
-        )
+        nx_inter_sep = self.user_options.nx_inter_sep
 
         # Adjust the number of points in upper and lower PF regions,
         # to keep nx constant between regions. This is because some regions
@@ -881,13 +873,13 @@ class TokamakEquilibrium(Equilibrium):
                 "grad_end": dpsidi_sep,
             },
             "inner_sol": {
-                "nx": self.user_options.nx_sol_inner - nx_inter_sep,
+                "nx": self.user_options.nx_sol_inner,
                 "psi_start": self.psi_sep[-1],
                 "psi_end": self.psi_sol_inner,
                 "grad_start": dpsidi_sep,
             },
             "outer_sol": {
-                "nx": self.user_options.nx_sol_outer - nx_inter_sep,
+                "nx": self.user_options.nx_sol_outer,
                 "psi_start": self.psi_sep[-1],
                 "psi_end": self.psi_sol,
                 "grad_start": dpsidi_sep,

--- a/hypnotoad/cases/tokamak.py
+++ b/hypnotoad/cases/tokamak.py
@@ -222,7 +222,7 @@ class TokamakEquilibrium(Equilibrium):
         # slightly displaced from the null so code can follow Grad(psi).
         # Number between 0. and 1.
         xpoint_offset=WithMeta(
-            0.5,
+            0.1,
             doc=(
                 "Tolerance for positioning points that should be at X-point, but need "
                 "to be slightly displaced from the null so code can follow Grad(psi)."

--- a/hypnotoad/cases/tokamak.py
+++ b/hypnotoad/cases/tokamak.py
@@ -1337,8 +1337,6 @@ class TokamakEquilibrium(Equilibrium):
                 equilibrium=self,
                 name=name,
                 nSegments=len(region["segments"]),  # The number of radial regions
-                settings=dict(self.user_options),
-                nonorthogonal_settings=dict(self.nonorthogonal_options),
                 nx=[segments[seg_name]["nx"] for seg_name in region["segments"]],
                 ny=region["ny"],
                 ny_total=self.ny_total,

--- a/hypnotoad/cases/tokamak.py
+++ b/hypnotoad/cases/tokamak.py
@@ -889,6 +889,13 @@ class TokamakEquilibrium(Equilibrium):
         if nx_inter_sep == 0:
             print("Generating a connected double null")
 
+            # Only use psi of inner separatrix, not the outer one (if it is slightly
+            # different)
+            segments["upper_pf"]["psi_end"] = self.psi_sep[0]
+            segments["lower_pf"]["psi_end"] = self.psi_sep[0]
+            segments["inner_sol"]["psi_start"] = self.psi_sep[0]
+            segments["outer_sol"]["psi_start"] = self.psi_sep[0]
+
             # Description of each poloidal region
             leg_regions = {
                 "inner_lower_divertor": {

--- a/hypnotoad/cases/torpex.py
+++ b/hypnotoad/cases/torpex.py
@@ -507,8 +507,6 @@ class TORPEXMagneticField(Equilibrium):
                 equilibrium=self,
                 name=name,
                 nSegments=2,
-                settings=dict(self.user_options),
-                nonorthogonal_settings=dict(self.nonorthogonal_options),
                 nx=legoptions[name]["nx"],
                 ny=legoptions[name]["ny"],
                 kind=legoptions[name]["kind"],

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -1841,6 +1841,9 @@ class EquilibriumRegion(PsiContour):
         if self.kind.split(".")[0] == "wall":
             sqrt_a_lower = None
             sqrt_b_lower = self.user_options.target_poloidal_spacing_length
+            nonorthogonal_orthogonal_d_lower = (
+                self.user_options.target_poloidal_spacing_length
+            )
             monotonic_d_lower = (
                 self.nonorthogonal_options.nonorthogonal_target_poloidal_spacing_length
             )
@@ -1856,6 +1859,9 @@ class EquilibriumRegion(PsiContour):
         elif self.kind.split(".")[0] == "X":
             sqrt_a_lower = self.user_options.xpoint_poloidal_spacing_length
             sqrt_b_lower = 0.0
+            nonorthogonal_orthogonal_d_lower = (
+                self.user_options.xpoint_poloidal_spacing_length
+            )
             monotonic_d_lower = (
                 self.nonorthogonal_options.nonorthogonal_xpoint_poloidal_spacing_length
             )
@@ -1873,6 +1879,9 @@ class EquilibriumRegion(PsiContour):
         if self.kind.split(".")[1] == "wall":
             sqrt_a_upper = None
             sqrt_b_upper = self.user_options.target_poloidal_spacing_length
+            nonorthogonal_orthogonal_d_upper = (
+                self.user_options.target_poloidal_spacing_length
+            )
             monotonic_d_upper = (
                 self.nonorthogonal_options.nonorthogonal_target_poloidal_spacing_length
             )
@@ -1888,6 +1897,9 @@ class EquilibriumRegion(PsiContour):
         elif self.kind.split(".")[1] == "X":
             sqrt_a_upper = self.user_options.xpoint_poloidal_spacing_length
             sqrt_b_upper = 0.0
+            nonorthogonal_orthogonal_d_upper = (
+                self.user_options.xpoint_poloidal_spacing_length
+            )
             monotonic_d_upper = (
                 self.nonorthogonal_options.nonorthogonal_xpoint_poloidal_spacing_length
             )
@@ -1910,6 +1922,8 @@ class EquilibriumRegion(PsiContour):
             "sqrt_b_upper": sqrt_b_upper,
             "monotonic_d_lower": monotonic_d_lower,
             "monotonic_d_upper": monotonic_d_upper,
+            "nonorthogonal_orthogonal_d_lower": nonorthogonal_orthogonal_d_lower,
+            "nonorthogonal_orthogonal_d_upper": nonorthogonal_orthogonal_d_upper,
             "nonorthogonal_range_lower": nonorthogonal_range_lower,
             "nonorthogonal_range_upper": nonorthogonal_range_upper,
             "nonorthogonal_range_lower_inner": nonorthogonal_range_lower_inner,
@@ -2053,7 +2067,9 @@ class EquilibriumRegion(PsiContour):
                 f"{prefix}xpoint_poloidal_spacing_length."
             )
 
-    def getSfuncFixedSpacing(self, npoints, distance, *, method=None):
+    def getSfuncFixedSpacing(
+        self, npoints, distance, *, method=None, spacing_lower=None, spacing_upper=None
+    ):
         if method is None:
             if self.user_options.orthogonal:
                 method = self.user_options.poloidal_spacing_method
@@ -2081,20 +2097,29 @@ class EquilibriumRegion(PsiContour):
             )
             self._checkMonotonic([(sfunc, "sqrt")], total_distance=distance)
         elif method == "monotonic":
+            if spacing_lower is None:
+                spacing_lower = spacings["monotonic_d_lower"]
+            if spacing_upper is None:
+                spacing_upper = spacings["monotonic_d_upper"]
             sfunc = self.getMonotonicPoloidalDistanceFunc(
                 distance,
                 npoints - 1,
                 self.user_options.N_norm_prefactor * self.ny_total,
-                d_lower=spacings["monotonic_d_lower"],
-                d_upper=spacings["monotonic_d_upper"],
+                d_lower=spacing_lower,
+                d_upper=spacing_upper,
             )
-            self._checkMonotonic([(sfunc, "sqrt")], total_distance=distance)
+            self._checkMonotonic([(sfunc, "monotonic")], total_distance=distance)
         elif method == "nonorthogonal":
             if (
                 self.nonorthogonal_options.nonorthogonal_spacing_method
                 == "poloidal_orthogonal_combined"
             ):
-                return self.combineSfuncs(self, None)
+                return self.combineSfuncs(
+                    self,
+                    None,
+                    spacing_lower=spacing_lower,
+                    spacing_upper=spacing_upper,
+                )
             elif (
                 self.nonorthogonal_options.nonorthogonal_spacing_method
                 == "perp_orthogonal_combined"
@@ -2119,23 +2144,43 @@ class EquilibriumRegion(PsiContour):
                     # the X-point
                     upper_surface = None
 
-                sfunc = self.combineSfuncs(self, None, lower_surface, upper_surface)
+                sfunc = self.combineSfuncs(
+                    self,
+                    None,
+                    lower_surface,
+                    upper_surface,
+                    spacing_lower=spacings["nonorthogonal_orthogonal_d_lower"],
+                    spacing_upper=spacings["nonorthogonal_orthogonal_d_upper"],
+                )
             elif self.nonorthogonal_options.nonorthogonal_spacing_method == "combined":
                 # Use fixed poloidal spacing when gridding the separatrix contour so that
                 # the grid spacing is the same in different regions which share a
                 # separatrix segment but have different perpendicular vectors at the
                 # X-point
-                return self.combineSfuncs(self, None)
+                return self.combineSfuncs(
+                    self,
+                    None,
+                    spacing_lower=spacings["nonorthogonal_orthogonal_d_lower"],
+                    spacing_upper=spacings["nonorthogonal_orthogonal_d_upper"],
+                )
             elif (
                 self.nonorthogonal_options.nonorthogonal_spacing_method == "orthogonal"
             ):
                 orth_method = self.user_options.poloidal_spacing_method
-                sfunc = self.getSfuncFixedSpacing(npoints, distance, method=orth_method)
+                sfunc = self.getSfuncFixedSpacing(
+                    npoints,
+                    distance,
+                    method=orth_method,
+                    spacing_lower=spacings["nonorthogonal_orthogonal_d_lower"],
+                    spacing_upper=spacings["nonorthogonal_orthogonal_d_upper"],
+                )
             else:
                 sfunc = self.getSfuncFixedSpacing(
                     npoints,
                     distance,
                     method=self.nonorthogonal_options.nonorthogonal_spacing_method,
+                    spacing_lower=spacings["nonorthogonal_orthogonal_d_lower"],
+                    spacing_upper=spacings["nonorthogonal_orthogonal_d_upper"],
                 )
         else:
             raise ValueError(
@@ -2158,7 +2203,18 @@ class EquilibriumRegion(PsiContour):
 
         return sfunc
 
-    def combineSfuncs(self, contour, sfunc_orthogonal, vec_lower=None, vec_upper=None):
+    def combineSfuncs(
+        self,
+        contour,
+        sfunc_orthogonal,
+        vec_lower=None,
+        vec_upper=None,
+        # spacing_lower/upper used only on the separatrix contours
+        # (equilibriumRegion objects) to allow the user to fine-tune spacings spacings
+        # set by 'sfunc_orthogonal's
+        spacing_lower=None,
+        spacing_upper=None,
+    ):
         # this sfunc gives:
         # * - if vec_lower is None: fixed poloidal spacing at the beginning of the
         #     contour
@@ -2173,20 +2229,38 @@ class EquilibriumRegion(PsiContour):
         #   the same spacing is given
         if vec_lower is None:
             sfunc_fixed_lower = self.getSfuncFixedSpacing(
-                2 * self.ny_noguards + 1, contour.totalDistance(), method="monotonic"
+                2 * self.ny_noguards + 1,
+                contour.totalDistance(),
+                method="monotonic",
+                spacing_lower=spacing_lower,
+                spacing_upper=spacing_upper,
             )
         else:
             sfunc_fixed_lower, sperp_func_lower = self.getSfuncFixedPerpSpacing(
-                2 * self.ny_noguards + 1, contour, vec_lower, True
+                2 * self.ny_noguards + 1,
+                contour,
+                vec_lower,
+                True,
+                spacing_lower=spacing_lower,
+                spacing_upper=spacing_upper,
             )
 
         if vec_upper is None:
             sfunc_fixed_upper = self.getSfuncFixedSpacing(
-                2 * self.ny_noguards + 1, contour.totalDistance(), method="monotonic"
+                2 * self.ny_noguards + 1,
+                contour.totalDistance(),
+                method="monotonic",
+                spacing_lower=spacing_lower,
+                spacing_upper=spacing_upper,
             )
         else:
             sfunc_fixed_upper, sperp_func_upper = self.getSfuncFixedPerpSpacing(
-                2 * self.ny_noguards + 1, contour, vec_upper, False
+                2 * self.ny_noguards + 1,
+                contour,
+                vec_upper,
+                False,
+                spacing_lower=spacing_lower,
+                spacing_upper=spacing_upper,
             )
 
         spacings = self.getSpacings()
@@ -2411,7 +2485,15 @@ class EquilibriumRegion(PsiContour):
 
         return new_sfunc
 
-    def getSfuncFixedPerpSpacing(self, N, contour, surface_direction, lower):
+    def getSfuncFixedPerpSpacing(
+        self,
+        N,
+        contour,
+        surface_direction,
+        lower,
+        spacing_lower=None,
+        spacing_upper=None,
+    ):
         """
         Return a function s(i) giving poloidal distance as a function of index-number.
         Construct so that ds_perp/diN = d_lower at the lower end or ds_perp/diN = d_upper
@@ -2421,15 +2503,20 @@ class EquilibriumRegion(PsiContour):
         N_norm = self.user_options.N_norm_prefactor * self.ny_total
         spacings = self.getSpacings()
 
+        if spacing_lower is None:
+            spacing_lower = spacings["monotonic_d_lower"]
+        if spacing_upper is None:
+            spacing_upper = spacings["monotonic_d_upper"]
+
         if self.wallSurfaceAtStart is None:
-            d_lower = spacings["monotonic_d_lower"] * self.sin_angle_at_start
+            d_lower = spacing_lower * self.sin_angle_at_start
         else:
-            d_lower = spacings["monotonic_d_lower"]
+            d_lower = spacing_lower
 
         if self.wallSurfaceAtEnd is None:
-            d_upper = spacings["monotonic_d_upper"] * self.sin_angle_at_end
+            d_upper = spacing_upper * self.sin_angle_at_end
         else:
-            d_upper = spacings["monotonic_d_upper"]
+            d_upper = spacing_upper
 
         s_of_sperp, s_perp_total = contour.interpSSperp(surface_direction)
         sperp_func = self.getMonotonicPoloidalDistanceFunc(

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -1663,7 +1663,7 @@ class EquilibriumRegion(PsiContour):
 
     nonorthogonal_options_factory = OptionsFactory(
         nonorthogonal_xpoint_poloidal_spacing_length=WithMeta(
-            5.0e-2,
+            1.0,
             doc=(
                 "Poloidal spacing of grid points near the X-point (for nonorthogonal "
                 "grids)"
@@ -1672,7 +1672,7 @@ class EquilibriumRegion(PsiContour):
             check_all=is_positive,
         ),
         nonorthogonal_xpoint_poloidal_spacing_range=WithMeta(
-            "nonorthogonal_xpoint_poloidal_spacing_length",
+            lambda options: 0.02 * options.nonorthogonal_xpoint_poloidal_spacing_length,
             doc=(
                 "Poloidal range over which to use perpendicular spacing near the "
                 "X-point. This range is used at the radial location of separatrices"
@@ -1681,7 +1681,7 @@ class EquilibriumRegion(PsiContour):
             check_all=is_non_negative_or_None,
         ),
         nonorthogonal_xpoint_poloidal_spacing_range_inner=WithMeta(
-            "nonorthogonal_xpoint_poloidal_spacing_range",
+            lambda options: 5.0 * options.nonorthogonal_xpoint_poloidal_spacing_range,
             doc=(
                 "Poloidal range over which to use perpendicular spacing near the "
                 "X-point. This range is used at 'inner' radial boundaries (core and PFR)"
@@ -1690,7 +1690,7 @@ class EquilibriumRegion(PsiContour):
             check_all=is_non_negative_or_None,
         ),
         nonorthogonal_xpoint_poloidal_spacing_range_outer=WithMeta(
-            "nonorthogonal_xpoint_poloidal_spacing_range",
+            lambda options: 5.0 * options.nonorthogonal_xpoint_poloidal_spacing_range,
             doc=(
                 "Poloidal range over which to use perpendicular spacing near the "
                 "X-point. This range is used at 'outer' radial boundaries (SOL)"
@@ -1699,7 +1699,7 @@ class EquilibriumRegion(PsiContour):
             check_all=is_non_negative_or_None,
         ),
         nonorthogonal_target_poloidal_spacing_length=WithMeta(
-            5.0e-2,
+            1.0,
             doc=(
                 "Poloidal spacing of grid points near the target (for nonorthogonal "
                 "grids)"
@@ -1708,7 +1708,7 @@ class EquilibriumRegion(PsiContour):
             check_all=is_positive,
         ),
         nonorthogonal_target_poloidal_spacing_range=WithMeta(
-            "nonorthogonal_target_poloidal_spacing_length",
+            lambda options: 0.1 * options.nonorthogonal_target_poloidal_spacing_length,
             doc=(
                 "Poloidal range over which to use perpendicular spacing near the "
                 "target. This range is used at the radial location of separatrices"

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -1616,7 +1616,7 @@ class EquilibriumRegion(PsiContour):
             allowed=["sqrt", "monotonic"],
         ),
         xpoint_poloidal_spacing_length=WithMeta(
-            lambda options: 5.0e-2 if options.orthogonal else 1.0,
+            lambda options: 5.0e-2 if options.orthogonal else 4.0,
             doc=(
                 "Spacing at the X-point end of a region (used for orthogonal grids). "
                 "Use None to not constrain the spacing."
@@ -1712,7 +1712,7 @@ class EquilibriumRegion(PsiContour):
             check_all=is_positive,
         ),
         nonorthogonal_target_poloidal_spacing_range=WithMeta(
-            lambda options: 0.1 * options.nonorthogonal_target_poloidal_spacing_length,
+            lambda options: 0.5 * options.nonorthogonal_target_poloidal_spacing_length,
             doc=(
                 "Poloidal range over which to use perpendicular spacing near the "
                 "target. This range is used at the radial location of separatrices"
@@ -1721,7 +1721,7 @@ class EquilibriumRegion(PsiContour):
             check_all=is_non_negative_or_None,
         ),
         nonorthogonal_target_poloidal_spacing_range_inner=WithMeta(
-            "nonorthogonal_target_poloidal_spacing_range",
+            lambda options: 2.0 * options.nonorthogonal_target_poloidal_spacing_range,
             doc=(
                 "Poloidal range over which to use perpendicular spacing near the "
                 "target. This range is used at 'inner' radial boundaries (core and PFR)"
@@ -1730,7 +1730,7 @@ class EquilibriumRegion(PsiContour):
             check_all=is_non_negative_or_None,
         ),
         nonorthogonal_target_poloidal_spacing_range_outer=WithMeta(
-            "nonorthogonal_target_poloidal_spacing_range",
+            lambda options: 2.0 * options.nonorthogonal_target_poloidal_spacing_range,
             doc=(
                 "Poloidal range over which to use perpendicular spacing near the "
                 "target. This range is used at 'outer' radial boundaries (SOL)"
@@ -1739,7 +1739,7 @@ class EquilibriumRegion(PsiContour):
             check_all=is_non_negative_or_None,
         ),
         nonorthogonal_radial_range_power=WithMeta(
-            1.0,
+            2.0,
             doc=(
                 "Controls radial transition between separatrix range value and inner "
                 "or outer range values"
@@ -2999,7 +2999,7 @@ class Equilibrium:
         # Update nonorthogonal defaults from settings in user_options
         self.nonorthogonal_options_factory = self.nonorthogonal_options_factory.add(
             nonorthogonal_xpoint_poloidal_spacing_length=(
-                self.user_options.xpoint_poloidal_spacing_length
+                0.25 * self.user_options.xpoint_poloidal_spacing_length
             ),
             nonorthogonal_target_poloidal_spacing_length=(
                 self.user_options.target_poloidal_spacing_length

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -745,14 +745,17 @@ class MeshRegion:
                     p_out = c_out[c_out.endInd]
                 return [p_out.R - p_in.R, p_out.Z - p_in.Z]
 
-            if self.nonorthogonal_options.nonorthogonal_spacing_method == "orthogonal":
+            if (
+                self.equilibriumRegion.nonorthogonal_options.nonorthogonal_spacing_method
+                == "orthogonal"
+            ):
                 warnings.warn(
                     "'orthogonal' option is not currently compatible with "
                     "extending grid past targets"
                 )
                 sfunc = self.sfunc_orthogonal_list[i_contour]
             elif (
-                self.nonorthogonal_options.nonorthogonal_spacing_method
+                self.equilibriumRegion.nonorthogonal_options.nonorthogonal_spacing_method
                 == "fixed_poloidal"
             ):
                 # this sfunc gives a fixed poloidal spacing at beginning and end of
@@ -763,28 +766,28 @@ class MeshRegion:
                     method="monotonic",
                 )
             elif (
-                self.nonorthogonal_options.nonorthogonal_spacing_method
+                self.equilibriumRegion.nonorthogonal_options.nonorthogonal_spacing_method
                 == "poloidal_orthogonal_combined"
             ):
                 sfunc = self.equilibriumRegion.combineSfuncs(
                     contour, self.sfunc_orthogonal_list[i_contour]
                 )
             elif (
-                self.nonorthogonal_options.nonorthogonal_spacing_method
+                self.equilibriumRegion.nonorthogonal_options.nonorthogonal_spacing_method
                 == "fixed_perp_lower"
             ):
                 sfunc = self.equilibriumRegion.getSfuncFixedPerpSpacing(
                     2 * self.ny_noguards + 1, contour, surface_vec(True), True
                 )
             elif (
-                self.nonorthogonal_options.nonorthogonal_spacing_method
+                self.equilibriumRegion.nonorthogonal_options.nonorthogonal_spacing_method
                 == "fixed_perp_upper"
             ):
                 sfunc = self.equilibriumRegion.getSfuncFixedPerpSpacing(
                     2 * self.ny_noguards + 1, contour, surface_vec(False), False
                 )
             elif (
-                self.nonorthogonal_options.nonorthogonal_spacing_method
+                self.equilibriumRegion.nonorthogonal_options.nonorthogonal_spacing_method
                 == "perp_orthogonal_combined"
             ):
                 sfunc = self.equilibriumRegion.combineSfuncs(
@@ -793,7 +796,10 @@ class MeshRegion:
                     surface_vec(True),
                     surface_vec(False),
                 )
-            elif self.nonorthogonal_options.nonorthogonal_spacing_method == "combined":
+            elif (
+                self.equilibriumRegion.nonorthogonal_options.nonorthogonal_spacing_method
+                == "combined"
+            ):
                 if self.equilibriumRegion.wallSurfaceAtStart is not None:
                     # use poloidal spacing near a wall
                     surface_vec_lower = None
@@ -815,7 +821,9 @@ class MeshRegion:
             else:
                 raise ValueError(
                     "Unrecognized option '"
-                    + str(self.nonorthogonal_options.nonorthogonal_spacing_method)
+                    + str(
+                        self.equilibriumRegion.nonorthogonal_options.nonorthogonal_spacing_method  # noqa: E501
+                    )
                     + "' for nonorthogonal poloidal spacing function"
                 )
 

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -2108,10 +2108,20 @@ class Mesh:
         l.set_draggable(True)
 
     def plotPoints(
-        self, xlow=False, ylow=False, corners=False, markers=None, ax=None, **kwargs
+        self,
+        xlow=False,
+        ylow=False,
+        corners=False,
+        markers=None,
+        ax=None,
+        plot_types="scatter",
+        **kwargs,
     ):
         from matplotlib import pyplot
         from cycler import cycle
+
+        if isinstance(plot_types, str):
+            plot_types = [plot_types]
 
         colors = cycle(pyplot.rcParams["axes.prop_cycle"].by_key()["color"])
 
@@ -2135,31 +2145,71 @@ class Mesh:
 
         for region in self.regions.values():
             c = next(colors)
-            m = iter(markers)
-            ax.scatter(
-                region.Rxy.centre,
-                region.Zxy.centre,
-                marker=next(m),
-                c=c,
-                label=region.myID,
-                **kwargs,
-            )
-            if xlow:
+
+            if "scatter" in plot_types:
+                m = iter(markers)
                 ax.scatter(
-                    region.Rxy.xlow, region.Zxy.xlow, marker=next(m), c=c, **kwargs
-                )
-            if ylow:
-                ax.scatter(
-                    region.Rxy.ylow, region.Zxy.ylow, marker=next(m), c=c, **kwargs
-                )
-            if corners:
-                ax.scatter(
-                    region.Rxy.corners,
-                    region.Zxy.corners,
+                    region.Rxy.centre,
+                    region.Zxy.centre,
                     marker=next(m),
                     c=c,
+                    label=region.myID,
                     **kwargs,
                 )
+                if xlow:
+                    ax.scatter(
+                        region.Rxy.xlow, region.Zxy.xlow, marker=next(m), c=c, **kwargs
+                    )
+                if ylow:
+                    ax.scatter(
+                        region.Rxy.ylow, region.Zxy.ylow, marker=next(m), c=c, **kwargs
+                    )
+                if corners:
+                    ax.scatter(
+                        region.Rxy.corners,
+                        region.Zxy.corners,
+                        marker=next(m),
+                        c=c,
+                        **kwargs,
+                    )
+            if "radial" in plot_types:
+                R = numpy.empty([2 * region.nx + 1, region.ny])
+                R[1::2, :] = region.Rxy.centre
+                R[::2, :] = region.Rxy.xlow
+                Z = numpy.empty([2 * region.nx + 1, region.ny])
+                Z[1::2, :] = region.Zxy.centre
+                Z[::2, :] = region.Zxy.xlow
+                lines = ax.plot(R, Z, linestyle="-", c=c,)
+                lines[0].set_label(region.myID)
+                if ylow:
+                    R = numpy.empty([2 * region.nx + 1, region.ny + 1])
+                    R[1::2, :] = region.Rxy.ylow
+                    R[::2, :] = region.Rxy.corners
+                    Z = numpy.empty([2 * region.nx + 1, region.ny + 1])
+                    Z[1::2, :] = region.Zxy.ylow
+                    Z[::2, :] = region.Zxy.corners
+                    ax.plot(
+                        R, Z, linestyle="--", c=c,
+                    )
+            if "poloidal" in plot_types:
+                R = numpy.empty([region.nx, 2 * region.ny + 1])
+                R[:, 1::2] = region.Rxy.centre
+                R[:, ::2] = region.Rxy.ylow
+                Z = numpy.empty([region.nx, 2 * region.ny + 1])
+                Z[:, 1::2] = region.Zxy.centre
+                Z[:, ::2] = region.Zxy.ylow
+                lines = ax.plot(R.T, Z.T, linestyle="-", c=c, label=region.myID)
+                lines[0].set_label(region.myID)
+                if ylow:
+                    R = numpy.empty([region.nx + 1, 2 * region.ny + 1])
+                    R[:, 1::2] = region.Rxy.xlow
+                    R[:, ::2] = region.Rxy.corners
+                    Z = numpy.empty([region.nx, 2 * region.ny + 1])
+                    Z[:, 1::2] = region.Zxy.xlow
+                    Z[:, ::2] = region.Zxy.corners
+                    ax.plot(
+                        R.T, Z.T, linestyle="--", c=c,
+                    )
         l = ax.legend()
         l.set_draggable(True)
 

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -560,6 +560,10 @@ class MeshRegion:
 
             # index of the segment of the contour that intersects the upper wall
             upper_intersect_index = -2
+
+            # starting orthogonal spacing function
+            sfunc_orthogonal = contour.contourSfunc()
+
             if lower_wall:
                 if upper_wall:
                     starti = len(contour) // 2

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -577,10 +577,11 @@ class MeshRegion:
                         break
 
                 count = 0
+                ds_extend = contour.distance[1] - contour.distance[0]
                 while lower_intersect is None:
                     # contour has not yet intersected with wall, so make it longer and
                     # try again
-                    contour.temporaryExtend(extend_lower=1)
+                    contour.temporaryExtend(extend_lower=1, ds_lower=ds_extend)
                     lower_intersect = self.meshParent.equilibrium.wallIntersection(
                         contour[1], contour[0]
                     )
@@ -606,10 +607,11 @@ class MeshRegion:
                         break
 
                 count = 0
+                ds_extend = contour.distance[-1] - contour.distance[-2]
                 while upper_intersect is None:
                     # contour has not yet intersected with wall, so make it longer and
                     # try again
-                    contour.temporaryExtend(extend_upper=1)
+                    contour.temporaryExtend(extend_upper=1, ds_upper=ds_extend)
                     upper_intersect = self.meshParent.equilibrium.wallIntersection(
                         contour[-2], contour[-1]
                     )

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -696,7 +696,10 @@ class MeshRegion:
             contour.refine(width=self.user_options.refine_width)
             contour.checkFineContourExtend()
 
-    def distributePointsNonorthogonal(self):
+    def distributePointsNonorthogonal(self, nonorthogonal_settings=None):
+        if nonorthogonal_settings is not None:
+            self.equilibriumRegion.resetNonorthogonalOptions(nonorthogonal_settings)
+
         # regrid the contours (which all know where the wall is)
         for i_contour, contour in enumerate(self.contours):
             print(
@@ -2029,18 +2032,14 @@ class Mesh:
             "'production' grid non-interactively to ensure reproducibility."
         )
 
-        self.nonorthogonal_options = self.nonorthogonal_options_factory.create(
-            nonorthogonal_settings
-        )
-        self.equilibrium.resetNonorthogonalOptions(dict(self.nonorthogonal_options))
+        self.equilibrium.resetNonorthogonalOptions(nonorthogonal_settings)
 
         assert (
             not self.user_options.orthogonal
         ), "redistributePoints would do nothing for an orthogonal grid."
         for region in self.regions.values():
             print("redistributing", region.name)
-            region.equilibriumRegion.setupOptions(force=True)
-            region.distributePointsNonorthogonal()
+            region.distributePointsNonorthogonal(nonorthogonal_settings)
 
     def calculateRZ(self):
         """

--- a/hypnotoad/gui/README.md
+++ b/hypnotoad/gui/README.md
@@ -1,0 +1,8 @@
+To generate the hypnotoad_mainWindow.py file, need pyside2 installed as well as
+Qt.py. Run:
+
+    $ pyside2-uic hypnotoad_mainWindow.ui -o hypnotoad_mainWindow.py
+    $ python -m Qt --convert hypnotoad_mainWindow.py
+
+The second step converts from a pyside2-specific file to one using Qt.py which
+can run with pyside, pyside2, PyQt4 or PyQt5.

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -485,16 +485,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
 
         self.statusbar.showMessage("Done!", 2000)
 
-        self.plot_widget.clear(keep_limits=True)
-        self.eq.plotPotential(ncontours=40, axis=self.plot_widget.axes)
-        self.eq.plotWall(axis=self.plot_widget.axes)
-        self.mesh.plotPoints(
-            xlow=self.gui_options["plot_xlow"],
-            ylow=self.gui_options["plot_ylow"],
-            corners=self.gui_options["plot_corners"],
-            ax=self.plot_widget.axes,
-        )
-        self.plot_widget.canvas.draw()
+        self.plot_grid(keep_limits=True)
 
     def write_grid(self):
         """Write generated mesh to file
@@ -528,8 +519,8 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
 
         self.mesh.writeGridfile(filename)
 
-    def plot_grid(self):
-        self.plot_widget.clear()
+    def plot_grid(self, *, keep_limits=False):
+        self.plot_widget.clear(keep_limits=keep_limits)
 
         if hasattr(self, "eq"):
             self.eq.plotPotential(ncontours=40, axis=self.plot_widget.axes)

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -476,7 +476,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.statusbar.showMessage("Running...")
 
         try:
-            self.mesh.redistributePoints()
+            self.mesh.redistributePoints(self.options)
         except ValueError as e:
             error_message = QErrorMessage()
             error_message.showMessage(str(e))

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -479,13 +479,10 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
 
         try:
             self.mesh.redistributePoints()
-        except ValueError:
-            self.statusbar.showMessage(
-                "Error in grid generation, change settings and regrid!"
-            )
-            self.statusbar.setStyleSheet(
-                f"QLineEdit {{ background-color: {COLOURS['red']} }}"
-            )
+        except ValueError as e:
+            error_message = QErrorMessage()
+            error_message.showMessage(str(e))
+            error_message.exec_()
             self.plot_widget.clear(keep_limits=True)
             return
 

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -260,11 +260,18 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
             filtered_default_values = dict(
                 tokamak.TokamakEquilibrium.user_options_factory.create(self.options)
             )
-            filtered_default_values.update(
-                tokamak.TokamakEquilibrium.nonorthogonal_options_factory.create(
-                    self.options
+            if not hasattr(self, "eq"):
+                filtered_default_values.update(
+                    tokamak.TokamakEquilibrium.nonorthogonal_options_factory.create(
+                        self.options
+                    )
                 )
-            )
+            else:
+                # Use the object if it exists because some defaults are updated when the
+                # Equilibrium is created
+                filtered_default_values.update(
+                    self.eq.nonorthogonal_options_factory.create(self.options)
+                )
         except (ValueError, TypeError) as e:
             self._popup_error_message(e)
             return

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -125,9 +125,6 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.gui_options = DEFAULT_GUI_OPTIONS
         self.filename = DEFAULT_OPTIONS_FILENAME
 
-        self.regrid_button.setEnabled(not self.options["orthogonal"])
-        self.action_Regrid.setEnabled(not self.options["orthogonal"])
-
         self.search_bar.setPlaceholderText("Search options...")
         self.search_bar.textChanged.connect(self.search_options_form)
         self.search_bar.setToolTip(self.search_options_form.__doc__.strip())
@@ -168,8 +165,6 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
 
         self.statusbar.showMessage("Reverting options", 2000)
         self.options = DEFAULT_OPTIONS
-        self.regrid_button.setEnabled(not self.options["orthogonal"])
-        self.action_Regrid.setEnabled(not self.options["orthogonal"])
 
         options_filename = self.options_file_line_edit.text()
 
@@ -348,7 +343,6 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.options_file_line_edit.setText(filename)
         self.filename = filename
         self.read_options()
-        self.nonorthogonal_box.setEnabled(True)
         self.nonorthogonal_box.setChecked(not self.options["orthogonal"])
 
     def read_options(self):
@@ -422,10 +416,11 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         # Delete mesh if it exists, since we have a new self.eq object
         if hasattr(self, "mesh"):
             del self.mesh
+        self.regrid_button.setEnabled(False)
+        self.action_Regrid.setEnabled(False)
 
         self.plot_grid()
 
-        self.nonorthogonal_box.setEnabled(True)
         self.nonorthogonal_box.setChecked(not self.options["orthogonal"])
 
     def run(self):
@@ -465,9 +460,6 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
     def set_nonorthogonal(self, state):
         state = bool(state)
         self.options["orthogonal"] = not state
-        if hasattr(self, "mesh"):
-            self.regrid_button.setEnabled(state)
-            self.action_Regrid.setEnabled(state)
 
     def regrid(self):
         """Regrid a nonorthogonal grid after spacing settings are changed

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -41,6 +41,12 @@ DEFAULT_OPTIONS_FILENAME = "Untitled.yml"
 YAML_FILTER = "YAML file (*.yml *.yaml)"
 NETCDF_FILTER = "NetCDF (*nc)"
 
+DEFAULT_OPTIONS = {
+    "orthogonal": tokamak.TokamakEquilibrium.user_options_factory.defaults[
+        "orthogonal"
+    ].value
+}
+
 DEFAULT_GUI_OPTIONS = {
     "grid_file": "bout.grd.nc",
     "plot_xlow": True,
@@ -115,7 +121,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
 
         self.action_Quit.triggered.connect(self.close)
 
-        self.options = {}
+        self.options = DEFAULT_OPTIONS
         self.gui_options = DEFAULT_GUI_OPTIONS
         self.filename = DEFAULT_OPTIONS_FILENAME
 
@@ -161,7 +167,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         """
 
         self.statusbar.showMessage("Reverting options", 2000)
-        self.options = {}
+        self.options = DEFAULT_OPTIONS
         self.regrid_button.setEnabled(not self.options["orthogonal"])
         self.action_Regrid.setEnabled(not self.options["orthogonal"])
 

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -487,7 +487,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
 
         self.plot_widget.clear(keep_limits=True)
         self.eq.plotPotential(ncontours=40, axis=self.plot_widget.axes)
-        self.eq.plotWall(ax=self.plot_widget.axes)
+        self.eq.plotWall(axis=self.plot_widget.axes)
         self.mesh.plotPoints(
             xlow=self.gui_options["plot_xlow"],
             ylow=self.gui_options["plot_ylow"],

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -406,9 +406,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
                     nonorthogonal_settings=copy.deepcopy(self.options),
                 )
         except (ValueError, RuntimeError) as e:
-            error_message = QErrorMessage()
-            error_message.showMessage(str(e))
-            error_message.exec_()
+            self._popup_error_message(e)
             return
 
         self.update_options_form()
@@ -443,9 +441,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         try:
             self.mesh = BoutMesh(self.eq, self.options)
         except (ValueError, SolutionError) as e:
-            error_message = QErrorMessage()
-            error_message.showMessage(str(e))
-            error_message.exec_()
+            self._popup_error_message(e)
             return
 
         self.mesh.calculateRZ()
@@ -478,10 +474,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         try:
             self.mesh.redistributePoints(self.options)
         except (ValueError, TypeError) as e:
-            error_message = QErrorMessage()
-            error_message.showMessage(str(e))
-            error_message.exec_()
-            self.plot_widget.clear(keep_limits=True)
+            self._popup_error_message(e)
             return
 
         self.statusbar.showMessage("Done!", 2000)
@@ -553,6 +546,12 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
             self.plot_widget.axes.plot(*self.eq.x_points[0], "rx")
 
         self.plot_widget.canvas.draw()
+
+    def _popup_error_message(self, error):
+        error_message = QErrorMessage()
+        error_message.showMessage(str(error))
+        error_message.exec_()
+        self.plot_widget.clear(keep_limits=True)
 
 
 class Preferences(QDialog, Ui_Preferences):

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -241,7 +241,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
 
     def update_options_form(self):
         """Update the widget values in the options form, based on the current
-        values in the options object
+        values in self.options
 
         """
 
@@ -256,14 +256,19 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
 
         # evaluate filtered_defaults using the values in self.options, so that any
         # expressions get evaluated
-        filtered_default_values = dict(
-            tokamak.TokamakEquilibrium.user_options_factory.create(self.options)
-        )
-        filtered_default_values.update(
-            tokamak.TokamakEquilibrium.nonorthogonal_options_factory.create(
-                self.options
+        try:
+            filtered_default_values = dict(
+                tokamak.TokamakEquilibrium.user_options_factory.create(self.options)
             )
-        )
+            filtered_default_values.update(
+                tokamak.TokamakEquilibrium.nonorthogonal_options_factory.create(
+                    self.options
+                )
+            )
+        except (ValueError, TypeError) as e:
+            self._popup_error_message(e)
+            return
+
         # Skip options handled specially elsewhere
         del filtered_options["orthogonal"]
         del filtered_defaults["orthogonal"]

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -478,6 +478,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
 
         try:
             self.mesh.redistributePoints(self.options)
+            self.mesh.calculateRZ()
         except (ValueError, TypeError) as e:
             self._popup_error_message(e)
             return

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -557,7 +557,6 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         error_message = QErrorMessage()
         error_message.showMessage(str(error))
         error_message.exec_()
-        self.plot_widget.clear(keep_limits=True)
 
 
 class Preferences(QDialog, Ui_Preferences):

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -476,7 +476,19 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
             return
 
         self.statusbar.showMessage("Running...")
-        self.mesh.redistributePoints()
+
+        try:
+            self.mesh.redistributePoints()
+        except ValueError:
+            self.statusbar.showMessage(
+                "Error in grid generation, change settings and regrid!"
+            )
+            self.statusbar.setStyleSheet(
+                f"QLineEdit {{ background-color: {COLOURS['red']} }}"
+            )
+            self.plot_widget.clear(keep_limits=True)
+            return
+
         self.statusbar.showMessage("Done!", 2000)
 
         self.plot_widget.clear(keep_limits=True)

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -479,7 +479,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.mesh.redistributePoints()
         self.statusbar.showMessage("Done!", 2000)
 
-        self.plot_widget.clear()
+        self.plot_widget.clear(keep_limits=True)
         self.eq.plotPotential(ncontours=40, axis=self.plot_widget.axes)
         self.mesh.plotPoints(
             xlow=self.gui_options["plot_xlow"],

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -477,7 +477,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
 
         try:
             self.mesh.redistributePoints(self.options)
-        except ValueError as e:
+        except (ValueError, TypeError) as e:
             error_message = QErrorMessage()
             error_message.showMessage(str(e))
             error_message.exec_()

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -468,6 +468,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
     def set_nonorthogonal(self, state):
         state = bool(state)
         self.options["orthogonal"] = not state
+        self.update_options_form()
 
     def regrid(self):
         """Regrid a nonorthogonal grid after spacing settings are changed

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -493,6 +493,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
 
         self.plot_widget.clear(keep_limits=True)
         self.eq.plotPotential(ncontours=40, axis=self.plot_widget.axes)
+        self.eq.plotWall(ax=self.plot_widget.axes)
         self.mesh.plotPoints(
             xlow=self.gui_options["plot_xlow"],
             ylow=self.gui_options["plot_ylow"],

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -179,7 +179,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
 
         """
 
-        self.options = {}
+        self.options = DEFAULT_OPTIONS
         self.options_form.setRowCount(0)
         self.update_options_form()
 

--- a/hypnotoad/gui/hypnotoad_mainWindow.py
+++ b/hypnotoad/gui/hypnotoad_mainWindow.py
@@ -193,7 +193,7 @@ class Ui_Hypnotoad(object):
 
         self.nonorthogonal_box = QCheckBox(self.centralwidget)
         self.nonorthogonal_box.setObjectName(u"nonorthogonal_box")
-        self.nonorthogonal_box.setEnabled(False)
+        self.nonorthogonal_box.setEnabled(True)
 
         self.gridLayout_2.addWidget(self.nonorthogonal_box, 1, 6, 1, 1)
 

--- a/hypnotoad/gui/hypnotoad_mainWindow.py
+++ b/hypnotoad/gui/hypnotoad_mainWindow.py
@@ -115,6 +115,10 @@ class Ui_Hypnotoad(object):
         self.action_Preferences.setObjectName(u"action_Preferences")
         icon9 = QIcon(QIcon.fromTheme(u"document-properties"))
         self.action_Preferences.setIcon(icon9)
+        self.action_Regrid = QAction(Hypnotoad)
+        self.action_Regrid.setObjectName(u"action_Regrid")
+        self.action_Regrid.setEnabled(False)
+        self.action_Regrid.setIcon(icon6)
         self.centralwidget = QWidget(Hypnotoad)
         self.centralwidget.setObjectName(u"centralwidget")
         self.horizontalLayout_2 = QHBoxLayout(self.centralwidget)
@@ -139,50 +143,72 @@ class Ui_Hypnotoad(object):
 
         self.verticalLayout_2.addWidget(self.options_form)
 
-        self.horizontalLayout_3 = QHBoxLayout()
-        self.horizontalLayout_3.setObjectName(u"horizontalLayout_3")
-        self.options_file_label = QLabel(self.centralwidget)
-        self.options_file_label.setObjectName(u"options_file_label")
-
-        self.horizontalLayout_3.addWidget(self.options_file_label)
-
-        self.options_file_line_edit = QLineEdit(self.centralwidget)
-        self.options_file_line_edit.setObjectName(u"options_file_line_edit")
-
-        self.horizontalLayout_3.addWidget(self.options_file_line_edit)
-
+        self.gridLayout_2 = QGridLayout()
+        self.gridLayout_2.setObjectName(u"gridLayout_2")
         self.options_file_browse_button = QPushButton(self.centralwidget)
         self.options_file_browse_button.setObjectName(u"options_file_browse_button")
 
-        self.horizontalLayout_3.addWidget(self.options_file_browse_button)
-
-        self.geqdsk_file_label = QLabel(self.centralwidget)
-        self.geqdsk_file_label.setObjectName(u"geqdsk_file_label")
-
-        self.horizontalLayout_3.addWidget(self.geqdsk_file_label)
-
-        self.geqdsk_file_line_edit = QLineEdit(self.centralwidget)
-        self.geqdsk_file_line_edit.setObjectName(u"geqdsk_file_line_edit")
-
-        self.horizontalLayout_3.addWidget(self.geqdsk_file_line_edit)
+        self.gridLayout_2.addWidget(self.options_file_browse_button, 0, 2, 1, 1)
 
         self.geqdsk_file_browse_button = QPushButton(self.centralwidget)
         self.geqdsk_file_browse_button.setObjectName(u"geqdsk_file_browse_button")
 
-        self.horizontalLayout_3.addWidget(self.geqdsk_file_browse_button)
+        self.gridLayout_2.addWidget(self.geqdsk_file_browse_button, 0, 6, 1, 1)
+
+        self.options_file_line_edit = QLineEdit(self.centralwidget)
+        self.options_file_line_edit.setObjectName(u"options_file_line_edit")
+
+        self.gridLayout_2.addWidget(self.options_file_line_edit, 0, 1, 1, 1)
 
         self.run_button = QPushButton(self.centralwidget)
         self.run_button.setObjectName(u"run_button")
 
-        self.horizontalLayout_3.addWidget(self.run_button)
+        self.gridLayout_2.addWidget(self.run_button, 0, 7, 1, 1)
 
         self.write_grid_button = QPushButton(self.centralwidget)
         self.write_grid_button.setObjectName(u"write_grid_button")
 
-        self.horizontalLayout_3.addWidget(self.write_grid_button)
+        self.gridLayout_2.addWidget(self.write_grid_button, 0, 9, 1, 1)
+
+        self.geqdsk_file_line_edit = QLineEdit(self.centralwidget)
+        self.geqdsk_file_line_edit.setObjectName(u"geqdsk_file_line_edit")
+
+        self.gridLayout_2.addWidget(self.geqdsk_file_line_edit, 0, 4, 1, 1)
+
+        self.geqdsk_file_label = QLabel(self.centralwidget)
+        self.geqdsk_file_label.setObjectName(u"geqdsk_file_label")
+
+        self.gridLayout_2.addWidget(self.geqdsk_file_label, 0, 3, 1, 1)
+
+        self.options_file_label = QLabel(self.centralwidget)
+        self.options_file_label.setObjectName(u"options_file_label")
+
+        self.gridLayout_2.addWidget(self.options_file_label, 0, 0, 1, 1)
+
+        self.regrid_button = QPushButton(self.centralwidget)
+        self.regrid_button.setObjectName(u"regrid_button")
+        self.regrid_button.setEnabled(False)
+
+        self.gridLayout_2.addWidget(self.regrid_button, 1, 7, 1, 1)
+
+        self.nonorthogonal_box = QCheckBox(self.centralwidget)
+        self.nonorthogonal_box.setObjectName(u"nonorthogonal_box")
+        self.nonorthogonal_box.setEnabled(False)
+
+        self.gridLayout_2.addWidget(self.nonorthogonal_box, 1, 6, 1, 1)
 
 
-        self.verticalLayout_2.addLayout(self.horizontalLayout_3)
+        self.verticalLayout_2.addLayout(self.gridLayout_2)
+
+        self.horizontalLayout_4 = QHBoxLayout()
+        self.horizontalLayout_4.setObjectName(u"horizontalLayout_4")
+
+        self.verticalLayout_2.addLayout(self.horizontalLayout_4)
+
+        self.gridLayout = QGridLayout()
+        self.gridLayout.setObjectName(u"gridLayout")
+
+        self.verticalLayout_2.addLayout(self.gridLayout)
 
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
@@ -212,6 +238,12 @@ class Ui_Hypnotoad(object):
         self.toolBar = QToolBar(Hypnotoad)
         self.toolBar.setObjectName(u"toolBar")
         Hypnotoad.addToolBar(Qt.TopToolBarArea, self.toolBar)
+        self.toolBar_2 = QToolBar(Hypnotoad)
+        self.toolBar_2.setObjectName(u"toolBar_2")
+        Hypnotoad.addToolBar(Qt.TopToolBarArea, self.toolBar_2)
+        self.toolBar_3 = QToolBar(Hypnotoad)
+        self.toolBar_3.setObjectName(u"toolBar_3")
+        Hypnotoad.addToolBar(Qt.TopToolBarArea, self.toolBar_3)
 
         self.menubar.addAction(self.menu_File.menuAction())
         self.menubar.addAction(self.menu_Mesh.menuAction())
@@ -226,6 +258,7 @@ class Ui_Hypnotoad(object):
         self.menu_File.addAction(self.action_Quit)
         self.menu_Help.addAction(self.action_About)
         self.menu_Mesh.addAction(self.action_Run)
+        self.menu_Mesh.addAction(self.action_Regrid)
         self.menu_Mesh.addAction(self.action_Write_grid)
         self.toolBar.addAction(self.action_New)
         self.toolBar.addAction(self.action_Open)
@@ -275,18 +308,26 @@ class Ui_Hypnotoad(object):
 #endif // QT_CONFIG(shortcut)
         self.action_Revert.setText(QCoreApplication.translate("Hypnotoad", u"&Revert", None))
         self.action_Preferences.setText(QCoreApplication.translate("Hypnotoad", u"&Preferences...", None))
+        self.action_Regrid.setText(QCoreApplication.translate("Hypnotoad", u"Re&grid", None))
+        self.action_Regrid.setToolTip(QCoreApplication.translate("Hypnotoad", u"Regrid non-orthogonal mesh", None))
         ___qtablewidgetitem = self.options_form.horizontalHeaderItem(0)
         ___qtablewidgetitem.setText(QCoreApplication.translate("Hypnotoad", u"Name", None));
         ___qtablewidgetitem1 = self.options_form.horizontalHeaderItem(1)
         ___qtablewidgetitem1.setText(QCoreApplication.translate("Hypnotoad", u"Value", None));
-        self.options_file_label.setText(QCoreApplication.translate("Hypnotoad", u"Options file", None))
         self.options_file_browse_button.setText(QCoreApplication.translate("Hypnotoad", u"Browse", None))
-        self.geqdsk_file_label.setText(QCoreApplication.translate("Hypnotoad", u"geqdsk file", None))
         self.geqdsk_file_browse_button.setText(QCoreApplication.translate("Hypnotoad", u"Browse", None))
         self.run_button.setText(QCoreApplication.translate("Hypnotoad", u"Run", None))
         self.write_grid_button.setText(QCoreApplication.translate("Hypnotoad", u"Write Grid", None))
+        self.geqdsk_file_label.setText(QCoreApplication.translate("Hypnotoad", u"geqdsk file", None))
+        self.options_file_label.setText(QCoreApplication.translate("Hypnotoad", u"Options file", None))
+        self.regrid_button.setToolTip(QCoreApplication.translate("Hypnotoad", u"Recalculate spacing of non-orthogonal grids (check 'Non-Orthogonal' box to activate)", None))
+        self.regrid_button.setText(QCoreApplication.translate("Hypnotoad", u"Regrid", None))
+        self.nonorthogonal_box.setToolTip(QCoreApplication.translate("Hypnotoad", u"Check to generate non-orthogonal grids", None))
+        self.nonorthogonal_box.setText(QCoreApplication.translate("Hypnotoad", u"Non-Orthogonal", None))
         self.menu_File.setTitle(QCoreApplication.translate("Hypnotoad", u"&File", None))
         self.menu_Help.setTitle(QCoreApplication.translate("Hypnotoad", u"&Help", None))
         self.menu_Mesh.setTitle(QCoreApplication.translate("Hypnotoad", u"&Mesh", None))
         self.toolBar.setWindowTitle(QCoreApplication.translate("Hypnotoad", u"toolBar", None))
+        self.toolBar_2.setWindowTitle(QCoreApplication.translate("Hypnotoad", u"toolBar_2", None))
+        self.toolBar_3.setWindowTitle(QCoreApplication.translate("Hypnotoad", u"toolBar_3", None))
     # retranslateUi

--- a/hypnotoad/gui/hypnotoad_mainWindow.ui
+++ b/hypnotoad/gui/hypnotoad_mainWindow.ui
@@ -37,56 +37,88 @@
          </widget>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
-          <item>
-           <widget class="QLabel" name="options_file_label">
-            <property name="text">
-             <string>Options file</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="options_file_line_edit"/>
-          </item>
-          <item>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="2">
            <widget class="QPushButton" name="options_file_browse_button">
             <property name="text">
              <string>Browse</string>
             </property>
            </widget>
           </item>
-          <item>
-           <widget class="QLabel" name="geqdsk_file_label">
-            <property name="text">
-             <string>geqdsk file</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="geqdsk_file_line_edit"/>
-          </item>
-          <item>
+          <item row="0" column="6">
            <widget class="QPushButton" name="geqdsk_file_browse_button">
             <property name="text">
              <string>Browse</string>
             </property>
            </widget>
           </item>
-          <item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="options_file_line_edit"/>
+          </item>
+          <item row="0" column="7">
            <widget class="QPushButton" name="run_button">
             <property name="text">
              <string>Run</string>
             </property>
            </widget>
           </item>
-          <item>
+          <item row="0" column="9">
            <widget class="QPushButton" name="write_grid_button">
             <property name="text">
              <string>Write Grid</string>
             </property>
            </widget>
           </item>
+          <item row="0" column="4">
+           <widget class="QLineEdit" name="geqdsk_file_line_edit"/>
+          </item>
+          <item row="0" column="3">
+           <widget class="QLabel" name="geqdsk_file_label">
+            <property name="text">
+             <string>geqdsk file</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="options_file_label">
+            <property name="text">
+             <string>Options file</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="7">
+           <widget class="QPushButton" name="regrid_button">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>Recalculate spacing of non-orthogonal grids (check 'Non-Orthogonal' box to activate)</string>
+            </property>
+            <property name="text">
+             <string>Regrid</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="6">
+           <widget class="QCheckBox" name="nonorthogonal_box">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>Check to generate non-orthogonal grids</string>
+            </property>
+            <property name="text">
+             <string>Non-Orthogonal</string>
+            </property>
+           </widget>
+          </item>
          </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_4"/>
+        </item>
+        <item>
+         <layout class="QGridLayout" name="gridLayout"/>
         </item>
        </layout>
       </item>
@@ -130,6 +162,7 @@
      <string>&amp;Mesh</string>
     </property>
     <addaction name="action_Run"/>
+    <addaction name="action_Regrid"/>
     <addaction name="action_Write_grid"/>
    </widget>
    <addaction name="menu_File"/>
@@ -153,6 +186,28 @@
    <addaction name="action_Save_as"/>
    <addaction name="action_Run"/>
    <addaction name="action_Write_grid"/>
+  </widget>
+  <widget class="QToolBar" name="toolBar_2">
+   <property name="windowTitle">
+    <string>toolBar_2</string>
+   </property>
+   <attribute name="toolBarArea">
+    <enum>TopToolBarArea</enum>
+   </attribute>
+   <attribute name="toolBarBreak">
+    <bool>false</bool>
+   </attribute>
+  </widget>
+  <widget class="QToolBar" name="toolBar_3">
+   <property name="windowTitle">
+    <string>toolBar_3</string>
+   </property>
+   <attribute name="toolBarArea">
+    <enum>TopToolBarArea</enum>
+   </attribute>
+   <attribute name="toolBarBreak">
+    <bool>false</bool>
+   </attribute>
   </widget>
   <action name="action_New">
    <property name="icon">
@@ -262,9 +317,23 @@
   <action name="action_Preferences">
    <property name="icon">
     <iconset theme="document-properties"/>
-   </property>
    <property name="text">
     <string>&amp;Preferences...</string>
+   </property>
+  </action>
+  <action name="action_Regrid">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="icon">
+    <iconset theme="system-run">
+     <normaloff>.</normaloff>.</iconset>
+   </property>
+   <property name="text">
+    <string>Re&amp;grid</string>
+   </property>
+   <property name="toolTip">
+    <string>Regrid non-orthogonal mesh</string>
    </property>
   </action>
  </widget>

--- a/hypnotoad/gui/hypnotoad_mainWindow.ui
+++ b/hypnotoad/gui/hypnotoad_mainWindow.ui
@@ -102,7 +102,7 @@
           <item row="1" column="6">
            <widget class="QCheckBox" name="nonorthogonal_box">
             <property name="enabled">
-             <bool>false</bool>
+             <bool>true</bool>
             </property>
             <property name="toolTip">
              <string>Check to generate non-orthogonal grids</string>

--- a/hypnotoad/gui/matplotlib_widget.py
+++ b/hypnotoad/gui/matplotlib_widget.py
@@ -29,10 +29,18 @@ class MatplotlibWidget:
 
         self.clear()
 
-    def clear(self):
+    def clear(self, *, keep_limits=False):
         """
         Make sure the figure is in a nice state
         """
+
+        if keep_limits:
+            # slightly hacky way to clear axes, but prevents axis limits being reset when
+            # we redraw
+            for artist in self.axes.lines + self.axes.collections:
+                artist.remove()
+            self.axes.set_prop_cycle(None)
+            return
 
         self.axes.clear()
         self.figure.clear()

--- a/hypnotoad/scripts/hypnotoad_geqdsk.py
+++ b/hypnotoad/scripts/hypnotoad_geqdsk.py
@@ -50,22 +50,25 @@ def main():
     from ..core.mesh import BoutMesh
 
     mesh = BoutMesh(eq, settings=options)
-    mesh.geometry()
+    mesh.calculateRZ()
 
     if options.get("plot_mesh", False):
         try:
             import matplotlib.pyplot as plt
 
-            eq.plotPotential(ncontours=40)
-            plt.plot(*eq.x_points[0], "rx")
+            ax = eq.plotPotential(ncontours=40)
+            ax.plot(*eq.x_points[0], "rx")
             mesh.plotPoints(
                 xlow=options.get("plot_xlow", True),
                 ylow=options.get("plot_ylow", True),
                 corners=options.get("plot_corners", True),
+                ax=ax,
             )
             plt.show()
         except Exception as err:
             warnings.warn(str(err))
+
+    mesh.geometry()
 
     mesh.writeGridfile(options.get("grid_file", "bout.grd.nc"))
 

--- a/hypnotoad/test_suite/test_equilibrium.py
+++ b/hypnotoad/test_suite/test_equilibrium.py
@@ -592,10 +592,12 @@ class TestContour:
 
 
 class ThisEquilibrium(Equilibrium):
-    def __init__(self):
-        self.user_options = Equilibrium.user_options_factory.create(
-            {"refine_width": 1.0e-5, "refine_atol": 2.0e-8}
-        )
+    def __init__(self, settings=None):
+        if settings is None:
+            settings = {}
+        self.user_options = Equilibrium.user_options_factory.add(
+            refine_width=1.0e-5, refine_atol=2.0e-8
+        ).create(settings)
 
         super().__init__({})
 
@@ -699,7 +701,7 @@ class TestEquilibrium:
 class TestEquilibriumRegion:
     @pytest.fixture
     def eqReg(self):
-        equilib = ThisEquilibrium()
+        equilib = ThisEquilibrium(settings={"y_boundary_guards": 1})
         equilib.psi = lambda R, Z: R - Z
         n = 11.0
         points = [
@@ -709,8 +711,6 @@ class TestEquilibriumRegion:
             equilibrium=equilib,
             name="",
             nSegments=1,
-            settings={"y_boundary_guards": 1},
-            nonorthogonal_settings={},
             nx=[1],
             ny=5,
             kind="wall.wall",
@@ -882,8 +882,9 @@ class TestEquilibriumRegion:
         n = len(eqReg)
         L = eqReg.totalDistance()
 
-        eqReg.monotonic_d_lower = L
-        eqReg.monotonic_d_upper = L
+        eqReg.resetNonorthogonalOptions(
+            {"nonorthogonal_target_poloidal_spacing_length": L}
+        )
         eqReg.ny_total = n - 1
 
         def sfunc_orthogonal(i):


### PR DESCRIPTION
Collection of fixes make nonorthogonal grid generation run for tokamak case.

Also adds 'regrid' button to the gui. For nonorthogonal grids, after generating a grid, the `nonorthogonal_*` options can be changed, and the grid regenerated much more quickly than building from scratch.

Should be merged after #23 #24 and #25 

- [x] Updated `doc/whats-new.md` with a summary of the changes
