### PR TITLE
Save 'hthe' to grid files for orthogonal grids

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -7,6 +7,13 @@ What's new
 
 ### New Features
 
+- For orthogonal grids, save hy as 'hthe'. Allows backward compatibility with
+  codes that compute metric coefficients for themselves. hy and hthe
+  definitions are the same for orthogonal grids. They differ for non-orthogonal
+  grids, so hy is *not* written as 'hthe' for non-orthogonal grids, to prevent
+  silent errors (#39)\
+  By [John Omotani](https://github.com/johnomotani)
+
 - Options have associated `doc` attributes, visible as tool-tips in the GUI
   (#33)\
   By [John Omotani](https://github.com/johnomotani)

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -2433,6 +2433,10 @@ class BoutMesh(Mesh):
             for name in self.fields_to_output:
                 self.writeArray(name, self.__dict__[name], f)
 
+            if self.user_options.orthogonal:
+                # Also write hy as "hthe" for backward compatibility
+                self.writeArray("hthe", self.hy, f)
+
             # write the 1d fields
             for name in self.arrayXDirection_to_output:
                 self.writeArrayXDirection(name, self.__dict__[name], f)


### PR DESCRIPTION
~~Internal variable is called 'hy', which is only different from Hypnotoad-1's 'hthe' for non-orthogonal grids. For othogonal grids they are the same, so to support backward compatibility it is better to save 'hthe'.~~
Save a copy of `hy` as `hthe` for orthogonal grids, to support backward compatibility.

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [x] Closes #38
- [x] Updated `doc/whats-new.md` with a summary of the changes
