### PR TITLE
0.1.1 release candidate

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -2,8 +2,8 @@ What's new
 ==========
 
 
-0.1.1 (unreleased)
-------------------
+0.1.1
+-----
 
 ### New Features
 


### PR DESCRIPTION
I think it's useful to have a 0.1.1 release now, to get the backward-compatible `hthe` onto pip, and to make `hypnotoad` compatible with conda-forge (since we've removed the dependency on `options` and replaced with `optionsfactory`, which is available on conda-forge). This PR just updates the `whats-new.md` for the release.