### PR TITLE
argparse for command line scripts

### DIFF
--- a/hypnotoad/scripts/hypnotoad_geqdsk.py
+++ b/hypnotoad/scripts/hypnotoad_geqdsk.py
@@ -8,20 +8,23 @@
 #
 #
 
-import sys
 import warnings
 
 
 def main():
-    if len(sys.argv) < 2 or len(sys.argv) > 3:
-        raise ValueError("Usage is {} geqdsk_file [options.yaml]".format(sys.argv[0]))
+    from argparse import ArgumentParser
 
-    filename = sys.argv[1]
-    if len(sys.argv) == 3:
+    parser = ArgumentParser()
+    parser.add_argument("filename")
+    parser.add_argument("inputfile", nargs="?", default=None)
+    args = parser.parse_args()
+
+    filename = args.filename
+    if args.inputfile is not None:
         # Options yaml file
         import yaml
 
-        with open(sys.argv[2], "r") as inputfile:
+        with open(args.inputfile, "r") as inputfile:
             options = yaml.safe_load(inputfile)
     else:
         options = {}

--- a/hypnotoad/scripts/hypnotoad_torpex.py
+++ b/hypnotoad/scripts/hypnotoad_torpex.py
@@ -31,17 +31,21 @@ Note: positions of cell corners are generated first, grid points are then put in
 centre of the cell.
 """
 
-plotStuff = True
-
 
 def main():
-    if plotStuff:
+    from argparse import ArgumentParser
+
+    parser = ArgumentParser()
+    parser.add_argument("filename")
+    parser.add_argument("--noplot", action="store_true")
+    args = parser.parse_args()
+
+    if not args.noplot:
         from matplotlib import pyplot
-    from sys import argv
 
     from ..cases.torpex import createMesh
 
-    filename = argv[1]
+    filename = args.filename
     gridname = "torpex.grd.nc"
 
     mesh = createMesh(filename)
@@ -56,7 +60,7 @@ def main():
         traceback.print_tb(e.__traceback__)
         print("****************************************")
 
-    if plotStuff:
+    if not args.noplot:
         pyplot.figure()
         mesh.equilibrium.plotPotential()
         mesh.equilibrium.addWallToPlot()


### PR DESCRIPTION
Use `argparse` for command line arguments in `hypnotoad_geqdsk.py` and `hypnotoad_torpex.py`. Main benefit of this is that it automatically provides `-h`/`--help` functionality, and that lets us test when building the conda recipe that the commands exist by doing `hypnotoad_geqdsk -h` and `hypnotoad_torpex -h` without having to actually run anything. With the previous interface, the tests failed because unless the scripts were called with an actual gfile/input file then they raised an error.