### PR TITLE
Catch ImportError when setting Qt5Agg backend for MatplotlibWidget

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -2,6 +2,16 @@ What's new
 ==========
 
 
+0.1.3 (20th June 2020)
+----------------------
+
+### Internal changes
+
+- Warn instead of failing in case of ImportError when setting "Qt5Agg" backend
+  (#44)\
+  By [John Omotani](https://github.com/johnomotani)
+
+
 0.1.2 (20th June 2020)
 ----------------------
 
@@ -9,6 +19,7 @@ What's new
 
 - Use argparse in command line scripts (#42)\
   By [John Omotani](https://github.com/johnomotani)
+
 
 0.1.1 (9th June 2020)
 ---------------------

--- a/hypnotoad/gui/matplotlib_widget.py
+++ b/hypnotoad/gui/matplotlib_widget.py
@@ -6,11 +6,19 @@ import matplotlib
 from matplotlib.figure import Figure
 from Qt.QtWidgets import QVBoxLayout
 
-matplotlib.use("Qt5Agg")
-from matplotlib.backends.backend_qt5agg import (  # noqa: E402
-    FigureCanvasQTAgg as FigureCanvas,
-    NavigationToolbar2QT as NavigationToolbar,
-)
+try:
+    matplotlib.use("Qt5Agg")
+except ImportError:
+    # Continue for now, so that hypnotoad-gui -h works even on systems without a
+    # display. Useful for testing existence of the command for conda-forge.
+    import warnings
+
+    warnings.warn("Failed to load Qt5Agg backend, plotting widget will fail")
+else:
+    from matplotlib.backends.backend_qt5agg import (  # noqa: E402
+        FigureCanvasQTAgg as FigureCanvas,
+        NavigationToolbar2QT as NavigationToolbar,
+    )
 
 
 class MatplotlibWidget:


### PR DESCRIPTION
Allows running 'hypnotoad-gui -h' successfully even in a headless environment (no display). This is useful so we can check that hypnotoad-gui exists in the conda-forge tests.

- [x] Updated `doc/whats-new.md` with a summary of the changes
