### PR TITLE
Convert dict keys to list in argument to QCompleter

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -2,6 +2,15 @@ What's new
 ==========
 
 
+0.1.4 (21st June 2020)
+----------------------
+
+### Internal changes
+
+- Make compatible with v5.13 of pyside2 (#45)\
+  By [John Omotani](https://github.com/johnomotani)
+
+
 0.1.3 (20th June 2020)
 ----------------------
 

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -118,7 +118,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.search_bar.textChanged.connect(self.search_options_form)
         self.search_bar.setToolTip(self.search_options_form.__doc__.strip())
         self.search_bar_completer = QCompleter(
-            tokamak.TokamakEquilibrium.user_options_factory.defaults.keys()
+            list(tokamak.TokamakEquilibrium.user_options_factory.defaults.keys())
         )
         self.search_bar_completer.setCaseSensitivity(Qt.CaseInsensitive)
         self.search_bar.setCompleter(self.search_bar_completer)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
         "scipy~=1.4",
         "Qt.py~=1.2",
     ],
-    extras_require={"gui-pyside2": ["pyside2~=5.14"], "gui-PyQt5": ["PyQt5~=5.12"],},
+    extras_require={"gui-pyside2": ["pyside2~=5.13"], "gui-PyQt5": ["PyQt5~=5.12"],},
     python_requires=">=3.6",
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Makes hypnotoad compatible with pyside2 v5.13. Previously v5.14 was required, but v5.14 is not available on conda yet.

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [x] Updated `doc/whats-new.md` with a summary of the changes
