### PR TITLE
Update installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,36 @@
-Dependencies
-------------
-
-- options module ('pip3 install --user options')
-- yaml module ('pip3 install --user PyYAML')
-- scipy (recent enough version, tested with 1.3.0 'pip3 install --user --upgrade scipy')
-
-
 Installation
 ------------
 
+#### From conda
+
+``hypnotoad`` is available from the ``conda-forge`` channel. Install with
+
+    $ conda install -c conda-forge hypnotoad
+
+To use the GUI, one of PySide2 or PyQt5 is needed (PySide and PyQt4 may also
+work, but have not been tested). Install with
+
+    $ conda install -c conda-forge pyside2
+
+or
+
+    $ conda install -c conda-forge pyqt
+
 #### From PyPi
 
-The simplest way to get hypnotoad is by simply running
+``hypnotoad`` can be installed using ``pip`` by running
 
     $ pip install --user hypnotoad
+
+To use the GUI, one of PySide2 or PyQt5 is needed (PySide and PyQt4 may also
+work, but have not been tested). These can be fetched by choosing a variant.
+For PySide2 use
+
+    $ pip install --user hypnotoad[gui-pyside2]
+
+or for PyQt5 use
+
+    $ pip install --user hypnotoad[gui-PyQt5]
 
 #### git repo
 
@@ -23,12 +40,19 @@ from github
     $ git clone git@github.com:boutproject/hypnotoad.git
 
 You can install from the git repo with ``pip``, this is useful to get the
-executables added to your path. Make sure to do an 'editable' install using
+executables added to your path. If you use ``conda`` you may wish to first
+install the dependencies using
+
+    $ conda install boututils matplotlib netcdf4 numpy optionsfactory pyparsing pyqt pyyaml qt.py scipy
+
+(replacing ``pyqt`` with ``pyside2`` if you prefer PySide2 to PyQt5) to ensure
+they are not ``pip``-installed. Make sure to do an 'editable' install using
 ``-e`` or ``--editable`` option like
 
     $ cd hypnotoad
     $ pip install -e .
 
+(you may also need to ``pip``-install ``PySide2`` or ``PyQt5`` to use the GUI).
 This installs executables which use the code that's currently in the git repo,
 so if you edit or update it you will see the updates. If you install with ``pip
 install .`` (without the ``-e``) then ``pip`` can get confused because it can't

--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -2,6 +2,21 @@ What's new
 ==========
 
 
+0.2.0 (25th June 2020)
+----------------------
+
+### New features
+
+- Button allowing grid to be regenerated in the gui after nonorthogonal spacing
+  options are changed (#26)\
+  By [John Omotani](https://github.com/johnomotani)
+
+### Bug fixes
+
+- More robust generation of non-orthogonal grids for tokamak cases (#26)\
+  By [John Omotani](https://github.com/johnomotani)
+
+
 0.1.4 (21st June 2020)
 ----------------------
 
@@ -35,10 +50,6 @@ What's new
 
 ### New features
 
-- Button allowing grid to be regenerated in the gui after nonorthogonal spacing
-  options are changed (#26)\
-  By [John Omotani](https://github.com/johnomotani)
-
 - For orthogonal grids, save hy as 'hthe'. Allows backward compatibility with
   codes that compute metric coefficients for themselves. hy and hthe
   definitions are the same for orthogonal grids. They differ for non-orthogonal
@@ -64,9 +75,6 @@ What's new
 
 
 ### Bug fixes
-
-- More robust generation of non-orthogonal grids for tokamak cases (#26)\
-  By [John Omotani](https://github.com/johnomotani)
 
 - If an empty string is passed to a value in the options table of the GUI,
   resets the option to its default value. Previously this caused a crash (#25)\


### PR DESCRIPTION
Update `README.md` with installation instructions for `conda`, and new dependencies (`optionsfactory` instead of `options`, Qt things for the GUI).

Merge this once the `hypnotoad` recipe is merged on `conda-forge`.