### PR TITLE
Output poloidal coordinates

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -2,6 +2,15 @@ What's new
 ==========
 
 
+0.2.1 (unreleased)
+------------------
+
+### New features
+- ``y`` and ``theta`` poloidal coordinates written out by ``BoutMesh`` (#51,
+  fixes #49)\
+  By [John Omotani](https://github.com/johnomotani)
+
+
 0.2.0 (25th June 2020)
 ----------------------
 

--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -6,7 +6,7 @@ What's new
 ------------------
 
 ### New features
-- ``y`` and ``theta`` poloidal coordinates written out by ``BoutMesh`` (#51,
+- ``y-coord`` and ``theta`` poloidal coordinates written out by ``BoutMesh`` (#51,
   fixes #49)\
   By [John Omotani](https://github.com/johnomotani)
 

--- a/hypnotoad/cases/tokamak.py
+++ b/hypnotoad/cases/tokamak.py
@@ -538,7 +538,7 @@ class TokamakEquilibrium(Equilibrium):
             return (psi - self.psi_axis) / (self.psi_sep[0] - self.psi_axis)
 
         self.psi_core = with_default(
-            self.user_options.psi_core, psinorm_to_psi(self.user_options.psinorm_core),
+            self.user_options.psi_core, psinorm_to_psi(self.user_options.psinorm_core)
         )
         self.psi_sol = with_default(
             self.user_options.psi_sol, psinorm_to_psi(self.user_options.psinorm_sol)
@@ -1479,8 +1479,7 @@ class TokamakEquilibrium(Equilibrium):
 
     @handleMultiLocationArray
     def fpolprime(self, psi):
-        """psi-derivative of fpol
-        """
+        """psi-derivative of fpol"""
         return self.fprime_spl(psi * self.f_psi_sign)
 
     @handleMultiLocationArray
@@ -1492,8 +1491,7 @@ class TokamakEquilibrium(Equilibrium):
 
     @property
     def Bt_axis(self):
-        """Calculate toroidal field on axis
-        """
+        """Calculate toroidal field on axis"""
         return self.fpol(self.psi_axis) / self.o_point.R
 
 

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -1761,7 +1761,7 @@ class EquilibriumRegion(PsiContour):
     )
 
     def __init__(
-        self, *, equilibrium, name, nSegments, nx, ny, kind, ny_total, points, psival,
+        self, *, equilibrium, name, nSegments, nx, ny, kind, ny_total, points, psival
     ):
         self.equilibrium = equilibrium
         self.name = name

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -2295,10 +2295,10 @@ class BoutMesh(Mesh):
     Poloidal coordinates
     --------------------
     BoutMesh writes three poloidal coordinates to the grid file:
-    - `y` increments by `dy` between points and starts from zero at the beginning of the
-      global grid. `y` includes boundary cells and is single-valued (at a given radial
-      position) everywhere on the global grid. `y` has branch cuts adjacent to both
-      X-points in the core, and adjacent to the X-point in the PFRs.
+    - `y-coord` increments by `dy` between points and starts from zero at the beginning
+      of the global grid. `y` includes boundary cells and is single-valued (at a given
+      radial position) everywhere on the global grid. `y` has branch cuts adjacent to
+      both X-points in the core, and adjacent to the X-point in the PFRs.
     - `theta` increments by `dy` between points and goes from 0 to 2pi in the core
       region. The lower inner divertor leg has negative values. The lower outer divertor
       leg has values >2pi. The upper inner leg (if it exists) has values increasing
@@ -2620,7 +2620,7 @@ class BoutMesh(Mesh):
             y.ylow[:, :-1] = y.centre - 0.5 * self.dy.centre[:, :]
             y.ylow[:, -1] = y.centre[:, -1] + 0.5 * self.dy.centre[:, -1]
             y.attributes["bout_type"] = "Field2D"
-            self.writeArray("y", y, f)
+            self.writeArray("y-coord", y, f)
 
             # Create poloidal coordinate which goes from 0 to 2pi in the core region
             theta = deepcopy(y)

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -2177,7 +2177,7 @@ class Mesh:
                 Z = numpy.empty([2 * region.nx + 1, region.ny])
                 Z[1::2, :] = region.Zxy.centre
                 Z[::2, :] = region.Zxy.xlow
-                lines = ax.plot(R, Z, linestyle="-", c=c,)
+                lines = ax.plot(R, Z, linestyle="-", c=c)
                 lines[0].set_label(region.myID)
                 if ylow:
                     R = numpy.empty([2 * region.nx + 1, region.ny + 1])
@@ -2186,9 +2186,7 @@ class Mesh:
                     Z = numpy.empty([2 * region.nx + 1, region.ny + 1])
                     Z[1::2, :] = region.Zxy.ylow
                     Z[::2, :] = region.Zxy.corners
-                    ax.plot(
-                        R, Z, linestyle="--", c=c,
-                    )
+                    ax.plot(R, Z, linestyle="--", c=c)
             if "poloidal" in plot_types:
                 R = numpy.empty([region.nx, 2 * region.ny + 1])
                 R[:, 1::2] = region.Rxy.centre
@@ -2205,9 +2203,7 @@ class Mesh:
                     Z = numpy.empty([region.nx, 2 * region.ny + 1])
                     Z[:, 1::2] = region.Zxy.xlow
                     Z[:, ::2] = region.Zxy.corners
-                    ax.plot(
-                        R.T, Z.T, linestyle="--", c=c,
-                    )
+                    ax.plot(R.T, Z.T, linestyle="--", c=c)
         l = ax.legend()
         l.set_draggable(True)
 

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -2311,6 +2311,10 @@ class BoutMesh(Mesh):
         self.ny = sum(r.ny(0) for r in self.equilibrium.regions.values())
 
         self.ny_noguards = sum(r.ny_noguards for r in self.equilibrium.regions.values())
+        self.ny_core = sum(
+            r.ny_noguards for r in self.equilibrium.regions.values()
+            if r.kind == "X.X"
+        )
 
         self.fields_to_output = []
         self.arrayXDirection_to_output = []
@@ -2358,7 +2362,12 @@ class BoutMesh(Mesh):
                 ] = numpy.index_exp[x_regions[i], y_regions[reg_name]]
 
         # constant spacing in y for now
-        self.dy_scalar = 2.0 * numpy.pi / self.ny_noguards
+        if self.ny_core > 0:
+            # If there is a core region, set dy consistent with 0<=y<2pi in the core
+            self.dy_scalar = 2.0 * numpy.pi / self.ny_core
+        else:
+            # No core region, set dy consistent with 0<=y<2pi in whole domain
+            self.dy_scalar = 2.0 * numpy.pi / self.ny_noguards
 
     def geometry(self):
         # Call geometry() method of base class

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -2615,11 +2615,8 @@ class BoutMesh(Mesh):
             # x-sizes, but y is constant in x so only actually need values from a single
             # x-index.
             y.xlow = y.centre[0, numpy.newaxis, :]
-            y.ylow[:, :-1] = (
-                y.centre
-                - 0.5*self.dy.centre[:, :]
-            )
-            y.ylow[:, -1] = y.centre[:, -1] + 0.5*self.dy.centre[:, -1]
+            y.ylow[:, :-1] = y.centre - 0.5 * self.dy.centre[:, :]
+            y.ylow[:, -1] = y.centre[:, -1] + 0.5 * self.dy.centre[:, -1]
             y.attributes["bout_type"] = "Field2D"
             self.writeArray("y", y, f)
 
@@ -2630,8 +2627,8 @@ class BoutMesh(Mesh):
                 # Make zero of theta half a point before the start of the core region
                 t -= theta.ylow[0, numpy.newaxis, jyseps1_1 + myg + 1, numpy.newaxis]
                 if jyseps2_1 != jyseps1_2:
-                    # Has second divertor, subtract y-increment in upper divertor legs from
-                    # outer regions to make theta continuous in the core
+                    # Has second divertor, subtract y-increment in upper divertor legs
+                    # from outer regions to make theta continuous in the core
                     # Set from x=0 entries of centre because xlow and ylow have different
                     # x-sizes, but y is constant in x so only actually need values from a
                     # single x-index.

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -1716,9 +1716,6 @@ class MeshRegion:
             self.ShiftAngle.xlow = (
                 region.zShift.corners[:, -1] - self.zShift.corners[:, 0]
             ).reshape((-1, 1))
-        else:
-            self.ShiftAngle.centre = float("nan")
-            self.ShiftAngle.xlow = float("nan")
 
     def getNeighbour(self, face):
         if self.connections[face] is None:
@@ -2421,6 +2418,8 @@ class BoutMesh(Mesh):
             # Data taken from the first region in each y-group
             self.arrayXDirection_to_output.append(name)
             f = MultiLocationArray(self.nx, 1)
+            f.centre[...] = float("nan")
+            f.xlow[...] = float("nan")
             self.__dict__[name] = f
             f.attributes = self.y_groups[0][0].__dict__[name].attributes
             for y_group in self.y_groups:
@@ -2433,7 +2432,7 @@ class BoutMesh(Mesh):
                     f.attributes == f_region.attributes
                 ), "attributes of a field must be set consistently in every region"
                 if f_region._centre_array is not None:
-                    f.centre[self.region_indices[region.myID]] = f_region.centre
+                    f.centre[self.region_indices[region.myID][0], :] = f_region.centre
                 if f_region._xlow_array is not None:
                     f.xlow[self.region_indices[region.myID]] = f_region.xlow[:-1, :]
                 assert (

--- a/hypnotoad/geqdsk/_fileutils.py
+++ b/hypnotoad/geqdsk/_fileutils.py
@@ -34,7 +34,7 @@ class ChunkOutput:
         self.extraspaces = extraspaces
 
     def write(self, value):
-        """"
+        """
         Write a value to the output, adding a newline if needed
 
         Distinguishes between:
@@ -79,8 +79,7 @@ class ChunkOutput:
         return self
 
     def __exit__(self, type, value, traceback):
-        """Ensure that the chunk finishes with a new line
-        """
+        """Ensure that the chunk finishes with a new line"""
         if self.counter != 0:
             self.counter = 0
             self.fh.write("\n")

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -57,18 +57,14 @@ DEFAULT_GUI_OPTIONS = {
 
 
 def _table_item_edit_display(item):
-    """Hide the "(default)" marker on table items in the options form
-
-    """
+    """Hide the "(default)" marker on table items in the options form"""
     default_marker = " (default)"
     if item.text().endswith(default_marker):
         item.setText(item.text()[: -len(default_marker)])
 
 
 class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
-    """A graphical interface for Hypnotoad
-
-    """
+    """A graphical interface for Hypnotoad"""
 
     def __init__(self):
         super().__init__(None)
@@ -139,9 +135,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.update_options_form()
 
     def help_about(self):
-        """About Hypnotoad
-
-        """
+        """About Hypnotoad"""
 
         about_text = __doc__.strip()
         about_text += f"\nVersion : {__version__}"
@@ -151,9 +145,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         about_box.exec_()
 
     def open_preferences(self):
-        """GUI preferences and settings
-
-        """
+        """GUI preferences and settings"""
         preferences_window = Preferences(self)
         preferences_window.exec_()
 
@@ -175,18 +167,14 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
             self.update_options_form()
 
     def new_options(self):
-        """New set of options
-
-        """
+        """New set of options"""
 
         self.options = DEFAULT_OPTIONS
         self.options_form.setRowCount(0)
         self.update_options_form()
 
     def save_options(self):
-        """Save options to file
-
-        """
+        """Save options to file"""
 
         self.statusbar.showMessage("Saving...", 2000)
 
@@ -218,15 +206,13 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
             yaml.dump(options_to_save, f)
 
     def save_options_as(self):
-        """Save options to file with new filename
-
-        """
+        """Save options to file with new filename"""
 
         if not self.filename:
             self.filename = DEFAULT_OPTIONS_FILENAME
 
         self.filename, _ = QFileDialog.getSaveFileName(
-            self, "Save grid to file", self.filename, filter=YAML_FILTER,
+            self, "Save grid to file", self.filename, filter=YAML_FILTER
         )
 
         if not self.filename:
@@ -302,9 +288,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.options_form.cellChanged.connect(self.options_form_changed)
 
     def options_form_changed(self, row, column):
-        """Change the options form from the widget table
-
-        """
+        """Change the options form from the widget table"""
 
         item = self.options_form.item(row, column)
 
@@ -327,9 +311,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.update_options_form()
 
     def search_options_form(self, text):
-        """Search for specific options
-
-        """
+        """Search for specific options"""
 
         for i in range(self.options_form.rowCount()):
             row = self.options_form.item(i, 0)
@@ -338,12 +320,10 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
             self.options_form.setRowHidden(i, not matches)
 
     def select_options_file(self):
-        """Choose a Hypnotoad options file to load
-
-        """
+        """Choose a Hypnotoad options file to load"""
 
         filename, _ = QFileDialog.getOpenFileName(
-            self, "Open options file", ".", filter=YAML_FILTER,
+            self, "Open options file", ".", filter=YAML_FILTER
         )
 
         if (filename is None) or (filename == ""):
@@ -358,9 +338,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.nonorthogonal_box.setChecked(not self.options["orthogonal"])
 
     def read_options(self):
-        """Read the options file
-
-        """
+        """Read the options file"""
 
         self.statusbar.showMessage("Reading options", 2000)
         options_filename = self.options_file_line_edit.text()
@@ -373,9 +351,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.update_options_form()
 
     def select_geqdsk_file(self):
-        """Choose a "geqdsk" equilibrium file to open
-
-        """
+        """Choose a "geqdsk" equilibrium file to open"""
 
         filename, _ = QFileDialog.getOpenFileName(self, "Open geqdsk file", ".")
 
@@ -394,9 +370,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.read_geqdsk()
 
     def read_geqdsk(self):
-        """Read the equilibrium file
-
-        """
+        """Read the equilibrium file"""
 
         self.statusbar.showMessage("Reading geqdsk", 2000)
         geqdsk_filename = self.geqdsk_file_line_edit.text()
@@ -434,9 +408,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.nonorthogonal_box.setChecked(not self.options["orthogonal"])
 
     def run(self):
-        """Run Hypnotoad and generate the grid
-
-        """
+        """Run Hypnotoad and generate the grid"""
 
         if not hasattr(self, "eq"):
             self.statusbar.showMessage("Missing equilibrium file!")
@@ -471,9 +443,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.update_options_form()
 
     def regrid(self):
-        """Regrid a nonorthogonal grid after spacing settings are changed
-
-        """
+        """Regrid a nonorthogonal grid after spacing settings are changed"""
 
         if not hasattr(self, "mesh"):
             self.statusbar.showMessage("Generate grid first!")
@@ -496,9 +466,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.plot_grid(keep_limits=True)
 
     def write_grid(self):
-        """Write generated mesh to file
-
-        """
+        """Write generated mesh to file"""
 
         # Create all the geometrical quantities
         self.mesh.geometry()
@@ -559,8 +527,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
 
 
 class Preferences(QDialog, Ui_Preferences):
-    """Dialog box for editing Hypnotoad preferences
-    """
+    """Dialog box for editing Hypnotoad preferences"""
 
     def __init__(self, parent):
         super().__init__(parent)

--- a/setup.py
+++ b/setup.py
@@ -32,13 +32,13 @@ setuptools.setup(
         "scipy~=1.4",
         "Qt.py~=1.2",
     ],
-    extras_require={"gui-pyside2": ["pyside2~=5.13"], "gui-PyQt5": ["PyQt5~=5.12"],},
+    extras_require={"gui-pyside2": ["pyside2~=5.13"], "gui-PyQt5": ["PyQt5~=5.12"]},
     python_requires=">=3.6",
     entry_points={
         "console_scripts": [
             "hypnotoad_geqdsk = hypnotoad.scripts.hypnotoad_geqdsk:main",
             "hypnotoad_torpex = hypnotoad.scripts.hypnotoad_torpex:main",
         ],
-        "gui_scripts": ["hypnotoad-gui = hypnotoad.gui:main",],
+        "gui_scripts": ["hypnotoad-gui = hypnotoad.gui:main"],
     },
 )


### PR DESCRIPTION
Define `y`, `theta` and `chi` coordinates for output from `BoutMesh`.
- `y` increments by `dy` between points and starts from zero at the beginning of the global grid. `y` includes boundary cells and is single-valued (at a given radial position) everywhere on the global grid. `y` has branch cuts adjacent to both X-points in the core, and adjacent to the X-point in the PFRs.
- `theta` increments by `dy` between points and goes from 0 to 2pi in the core region. The lower inner divertor leg has negative values. The lower outer divertor leg has values >2pi. The upper inner leg (if it exists) has values increasing continuously from those in the inner SOL (these will overlap values in the outer core region). The outer upper leg (if it exists) has values continuous with those in the outer SOL (these will overlap values in the inner core region).
- `chi` is a straight-field line poloidal coordinate proportional to the toroidal angle (i.e. to zShift). It goes from 0 to 2pi in the core, and is undefined on open field lines.

Also includes fix for bug that meant `ShiftAngle` got written as all-`nan` even when there is a core region.

- [x] Closes #49 
- [x] Updated `doc/whats-new.md` with a summary of the changes
