### PR TITLE
Fix tokamak example

### DIFF
--- a/examples/tokamak/tokamak_example.py
+++ b/examples/tokamak/tokamak_example.py
@@ -96,12 +96,12 @@ if __name__ == "__main__":
     from hypnotoad import tokamak
 
     eq = tokamak.TokamakEquilibrium(
-        r1d, z1d, psi2d, [], [], options=options  # psi1d, fpol
+        r1d, z1d, psi2d, [], [], settings=options  # psi1d, fpol
     )
 
-    from hypnotoad.mesh import BoutMesh
+    from hypnotoad.core.mesh import BoutMesh
 
-    mesh = BoutMesh(eq)
+    mesh = BoutMesh(eq, options)
     mesh.geometry()
 
     import matplotlib.pyplot as plt

--- a/hypnotoad/scripts/hypnotoad_geqdsk.py
+++ b/hypnotoad/scripts/hypnotoad_geqdsk.py
@@ -52,7 +52,7 @@ def main():
 
     from ..core.mesh import BoutMesh
 
-    mesh = BoutMesh(eq, settings=options)
+    mesh = BoutMesh(eq, options)
     mesh.calculateRZ()
 
     if options.get("plot_mesh", False):


### PR DESCRIPTION
Keyword to TokamakEquilibrium renamed

Settings passed to BoutMesh are now a positional argument, not keyword

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [ ] Closes #52 
