### PR TITLE
Timeout if FineContour.refine takes too long

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -6,8 +6,15 @@ What's new
 ------------------
 
 ### New features
+
 - ``y-coord`` and ``theta`` poloidal coordinates written out by ``BoutMesh`` (#51,
   fixes #49)\
+  By [John Omotani](https://github.com/johnomotani)
+
+### Bug fixes
+
+- Timeout if FineContour.refine() takes too long. Length of timeout set by
+  refine_timeout option (#58)\
   By [John Omotani](https://github.com/johnomotani)
 
 

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -59,16 +59,14 @@ def refineTimeoutMessage(self):
     """
     # Try to gather the function name, if available.
     # If it is not, default to an "unknown" string to allow default instantiation
-    if self.timedOutAfter is not None:
-        timedOutAfterStr = "%f" % (self.timedOutAfter,)
-    else:
-        timedOutAfterStr = "Unknown"
+    if self.timedOutAfter is None:
+        self.timedOutAfter = "Unknown"
 
     fine_contour = self.timedOutArgs[0]
     contour = fine_contour.parentContour
 
     return (
-        f"Refining FineContour timed out after {timedOutAfterStr} seconds.\n"
+        f"Refining FineContour timed out after {self.timedOutAfter} seconds.\n"
         f"This probably means the PsiContour was problematic, e.g. too close to a "
         f"coil.\n"
         f"The length of the timeout can be set with the 'refine_timeout' option."

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -25,6 +25,7 @@ the potential.
 from collections import OrderedDict
 from collections.abc import Sequence
 from copy import deepcopy
+import func_timeout
 from optionsfactory import OptionsFactory, WithMeta
 from optionsfactory.checks import (
     NoneType,
@@ -47,6 +48,35 @@ class SolutionError(Exception):
     """
 
     pass
+
+
+# Monkey-patch FunctionTimedOut exception to give a more helpful error message
+def refineTimeoutMessage(self):
+    """
+    getMsg - Generate a message based on parameters to FunctionTimedOut exception
+
+    @return <str> - Message
+    """
+    # Try to gather the function name, if available.
+    # If it is not, default to an "unknown" string to allow default instantiation
+    if self.timedOutAfter is not None:
+        timedOutAfterStr = "%f" % (self.timedOutAfter,)
+    else:
+        timedOutAfterStr = "Unknown"
+
+    fine_contour = self.timedOutArgs[0]
+    contour = fine_contour.parentContour
+
+    return (
+        f"Refining FineContour timed out after {timedOutAfterStr} seconds.\n"
+        f"This probably means the PsiContour was problematic, e.g. too close to a "
+        f"coil.\n"
+        f"The length of the timeout can be set with the 'refine_timeout' option."
+        f"Debugging info: PsiContour was {contour}"
+    )
+
+
+func_timeout.FunctionTimedOut.getMsg = refineTimeoutMessage
 
 
 # tolerance used to try and avoid missed intersections between lines
@@ -376,6 +406,17 @@ class FineContour:
             value_type=int,
             check_all=is_positive,
         ),
+        refine_timeout=WithMeta(
+            10.0,
+            doc=(
+                "Timeout for refining FineContour objects in seconds. If you get "
+                "func_timeout.exceptions.FunctionTimedOut exceptions and you are sure "
+                "there is no problem with the grid, you could try increasing this "
+                "value."
+            ),
+            value_type=float,
+            check_all=is_positive,
+        ),
     )
 
     def __init__(self, parentContour, settings):
@@ -661,26 +702,33 @@ class FineContour:
         return lambda s: Point2D(float(interpR(s)), float(interpZ(s)))
 
     def refine(self):
-        result = numpy.zeros(self.positions.shape)
+        # Define inner method so we can pass to func_timeout.func_timeout
+        def refine(self):
+            result = numpy.zeros(self.positions.shape)
 
-        p = self.positions[0, :]
-        tangent = self.positions[1, :] - self.positions[0, :]
-        result[0, :] = self.parentContour.refinePoint(
-            Point2D(*p), Point2D(*tangent)
-        ).as_ndarray()
-        for i in range(1, self.positions.shape[0] - 1):
-            p = self.positions[i, :]
-            tangent = self.positions[i + 1, :] - self.positions[i - 1, :]
-            result[i, :] = self.parentContour.refinePoint(
+            p = self.positions[0, :]
+            tangent = self.positions[1, :] - self.positions[0, :]
+            result[0, :] = self.parentContour.refinePoint(
                 Point2D(*p), Point2D(*tangent)
             ).as_ndarray()
-        p = self.positions[-1, :]
-        tangent = self.positions[-1, :] - self.positions[-2, :]
-        result[-1, :] = self.parentContour.refinePoint(
-            Point2D(*p), Point2D(*tangent)
-        ).as_ndarray()
+            for i in range(1, self.positions.shape[0] - 1):
+                p = self.positions[i, :]
+                tangent = self.positions[i + 1, :] - self.positions[i - 1, :]
+                result[i, :] = self.parentContour.refinePoint(
+                    Point2D(*p), Point2D(*tangent)
+                ).as_ndarray()
+            p = self.positions[-1, :]
+            tangent = self.positions[-1, :] - self.positions[-2, :]
+            result[-1, :] = self.parentContour.refinePoint(
+                Point2D(*p), Point2D(*tangent)
+            ).as_ndarray()
 
-        self.positions = result
+            self.positions = result
+
+        # Using func_timeout.func_timeout rather than the @func_timeout.func_set_timeout
+        # decorator on the refine method so that we can use self.user_options to set the
+        # length of the timeout.
+        func_timeout.func_timeout(self.user_options.refine_timeout, refine, [self])
 
     def reverse(self):
         if self.distance is not None:

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -5,6 +5,7 @@ GUI for Hypnotoad using Qt
 
 import ast
 import copy
+import func_timeout
 import os
 import pathlib
 import textwrap
@@ -391,7 +392,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
                     settings=copy.deepcopy(self.options),
                     nonorthogonal_settings=copy.deepcopy(self.options),
                 )
-        except (ValueError, RuntimeError) as e:
+        except (ValueError, RuntimeError, func_timeout.FunctionTimedOut) as e:
             self._popup_error_message(e)
             return
 
@@ -424,7 +425,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.statusbar.showMessage("Running...")
         try:
             self.mesh = BoutMesh(self.eq, self.options)
-        except (ValueError, SolutionError) as e:
+        except (ValueError, SolutionError, func_timeout.FunctionTimedOut) as e:
             self._popup_error_message(e)
             return
 
@@ -457,7 +458,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         try:
             self.mesh.redistributePoints(self.options)
             self.mesh.calculateRZ()
-        except (ValueError, TypeError) as e:
+        except (ValueError, TypeError, func_timeout.FunctionTimedOut) as e:
             self._popup_error_message(e)
             return
 
@@ -469,7 +470,11 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         """Write generated mesh to file"""
 
         # Create all the geometrical quantities
-        self.mesh.geometry()
+        try:
+            self.mesh.geometry()
+        except (ValueError, TypeError, func_timeout.FunctionTimedOut) as e:
+            self._popup_error_message(e)
+            return
 
         if not hasattr(self, "mesh"):
             flags = QMessageBox.StandardButton.Ok

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     ],
     install_requires=[
         "boututils~=0.1.4",
-        "func_timeout~=4.3.5",
+        "func_timeout~=4.3",
         "matplotlib~=3.2",
         "netCDF4~=1.5",
         "numpy~=1.18",

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setuptools.setup(
     ],
     install_requires=[
         "boututils~=0.1.4",
+        "func_timeout~=4.3.5",
         "matplotlib~=3.2",
         "netCDF4~=1.5",
         "numpy~=1.18",


### PR DESCRIPTION
If the grid is bad for some reason, refining a `FineContour` may take an excessively long time. The refining would probably fail eventually, but iterations take so long that it may be better not to wait as it looks like hypnotoad is hanging, and the gui would be frozen while this happens. So add a timeout, which can be controlled with the `refine_timeout` option.

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [x] Updated `doc/whats-new.md` with a summary of the changes
