### PR TITLE
Developer docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,9 @@ accuracy. The following may be a good starting point:
   probably not be in exactly the same place, but the algorithms are intended to
   produce grid spacings that are inversely proportional to the total number of
   points, so the structure should be very similar.
+
+
+Developing
+----------
+
+Developer documentation is [here](doc/developer/developer.md).

--- a/doc/developer/developer.md
+++ b/doc/developer/developer.md
@@ -1,0 +1,6 @@
+Developing hypnotoad
+====================
+
+[GUI](../../hypnotoad/gui/README.md)
+
+[Release process](RELEASE_HOWTO.md)

--- a/hypnotoad/gui/README.md
+++ b/hypnotoad/gui/README.md
@@ -1,3 +1,15 @@
+The main functionality is implemented in `gui.py`. The windows are defined in the
+auto-generated `hypnotoad_mainWindow.py` and `hypnotoad_preferences.py` files, and
+hand-coded `matplotlib_widget.py`. The executable `hypnotoad-gui` is an 'entry-point'
+defined in `setup.py`, implemented in the `__main__.py` file.
+
+The `hypnotoad_mainWindow.py` file is auto-generated from the `hypnotoad_mainWindow.ui`
+file. `hypnotoad_mainWindow.ui` is produced by, and can be edited by, the `qtcreator`
+program, which should be available from your Linux distro's package manager.
+```
+$ qtcreator hypnotoad_mainWindow.ui
+```
+
 To generate the hypnotoad_mainWindow.py file, need pyside2 installed as well as
 Qt.py. Run:
 
@@ -6,3 +18,6 @@ Qt.py. Run:
 
 The second step converts from a pyside2-specific file to one using Qt.py which
 can run with pyside, pyside2, PyQt4 or PyQt5.
+
+Similarly the `hypnotoad_preferences.py` is generated from the
+`hypnotoad_preferences.ui` file.

--- a/hypnotoad/gui/hypnotoad_mainWindow.ui
+++ b/hypnotoad/gui/hypnotoad_mainWindow.ui
@@ -317,6 +317,7 @@
   <action name="action_Preferences">
    <property name="icon">
     <iconset theme="document-properties"/>
+   </property>
    <property name="text">
     <string>&amp;Preferences...</string>
    </property>


### PR DESCRIPTION
Some small updates to make the developer documentation easier to find (linked from the main `README.md`), and to mention `qtcreator`.

Also fixes a small error (bad merge?) in the `hypnotoad_mainWindow.ui` file.