### PR TITLE
Allow setting options for BoutMesh in GUI

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -7,6 +7,8 @@ What's new
 
 ### Bug fixes
 
+- BoutMesh options now settable in GUI (#63)
+  By [John Omotani](https://github.com/johnomotani)
 - Changing settings in File->Preferences caused GUI to crash (#62, fixes #61)\
   By [John Omotani](https://github.com/johnomotani)
 

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -1264,30 +1264,38 @@ class MeshRegion:
         if not numpy.all(check.centre):
             ploterror("centre")
             raise ValueError(
-                "Geometry: Jacobian at centre should be consistent with 1/sqrt(det(g)) "
-                "calculated from the metric tensor"
+                f"Geometry: Jacobian at centre should be consistent with "
+                f"1/sqrt(det(g)) calculated from the metric tensor. If the plot "
+                f"looks OK, you may want to increase the value of "
+                f"geometry_rtol={self.user_options.geometry_rtol}"
             )
 
         if not numpy.all(check.ylow):
             ploterror("ylow")
             raise ValueError(
-                "Geometry: Jacobian at ylow should be consistent with 1/sqrt(det(g)) "
-                "calculated from the metric tensor"
+                f"Geometry: Jacobian at ylow should be consistent with "
+                f"1/sqrt(det(g)) calculated from the metric tensor. If the plot "
+                f"looks OK, you may want to increase the value of "
+                f"geometry_rtol={self.user_options.geometry_rtol}"
             )
 
         if check._xlow_array is not None:
             if not numpy.all(check.xlow):
                 ploterror("xlow")
                 raise ValueError(
-                    "Geometry: Jacobian at xlow should be consistent with "
-                    "1/sqrt(det(g)) calculated from the metric tensor"
+                    f"Geometry: Jacobian at xlow should be consistent with "
+                    f"1/sqrt(det(g)) calculated from the metric tensor. If the "
+                    f"plot looks OK, you may want to increase the value of "
+                    f"geometry_rtol={self.user_options.geometry_rtol}"
                 )
         if check._corners_array is not None:
             if not numpy.all(check.corners):
                 ploterror("corners")
                 raise ValueError(
-                    "Geometry: Jacobian at corners should be consistent with "
-                    "1/sqrt(det(g)) calculated from the metric tensor"
+                    f"Geometry: Jacobian at corners should be consistent with "
+                    f"1/sqrt(det(g)) calculated from the metric tensor. If the "
+                    f"plot looks OK, you may want to increase the value of "
+                    f"geometry_rtol={self.user_options.geometry_rtol}"
                 )
 
         # curvature terms

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -125,9 +125,16 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.search_bar.setPlaceholderText("Search options...")
         self.search_bar.textChanged.connect(self.search_options_form)
         self.search_bar.setToolTip(self.search_options_form.__doc__.strip())
-        self.search_bar_completer = QCompleter(
-            list(tokamak.TokamakEquilibrium.user_options_factory.defaults.keys())
+        option_names = (
+            set(BoutMesh.user_options_factory.defaults.keys())
+            .union(set(tokamak.TokamakEquilibrium.user_options_factory.defaults.keys()))
+            .union(
+                set(
+                    tokamak.TokamakEquilibrium.nonorthogonal_options_factory.defaults.keys()
+                )
+            )
         )
+        self.search_bar_completer = QCompleter(option_names)
         self.search_bar_completer.setCaseSensitivity(Qt.CaseInsensitive)
         self.search_bar.setCompleter(self.search_bar_completer)
 

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -193,6 +193,11 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
             options_ = tokamak.TokamakEquilibrium.user_options_factory.create(
                 self.options
             )
+            options_.update(
+                tokamak.TokamakEquilibrium.nonorthogonal_options_factory.create(
+                    self.options
+                )
+            )
 
             # This converts any numpy types to native Python using the tolist()
             # method of any numpy objects/types. Note this does return a scalar

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -190,8 +190,9 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
 
         options_to_save = self.options
         if self.gui_options["save_full_yaml"]:
-            options_ = tokamak.TokamakEquilibrium.user_options_factory.create(
-                self.options
+            options_ = BoutMesh.user_options_factory.create(self.options)
+            options_.update(
+                tokamak.TokamakEquilibrium.user_options_factory.create(self.options)
             )
             options_.update(
                 tokamak.TokamakEquilibrium.nonorthogonal_options_factory.create(
@@ -239,7 +240,8 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
 
         filtered_options = copy.deepcopy(self.options)
 
-        filtered_defaults = dict(
+        filtered_defaults = dict(BoutMesh.user_options_factory.defaults)
+        filtered_defaults.update(
             tokamak.TokamakEquilibrium.user_options_factory.defaults
         )
         filtered_defaults.update(
@@ -248,8 +250,11 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
 
         # evaluate filtered_defaults using the values in self.options, so that any
         # expressions get evaluated
+        filtered_default_values = dict(
+            BoutMesh.user_options_factory.create(self.options)
+        )
         try:
-            filtered_default_values = dict(
+            filtered_default_values.update(
                 tokamak.TokamakEquilibrium.user_options_factory.create(self.options)
             )
             if not hasattr(self, "eq"):

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -130,7 +130,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
             .union(set(tokamak.TokamakEquilibrium.user_options_factory.defaults.keys()))
             .union(
                 set(
-                    tokamak.TokamakEquilibrium.nonorthogonal_options_factory.defaults.keys()
+                    tokamak.TokamakEquilibrium.nonorthogonal_options_factory.defaults.keys()  # noqa: E501
                 )
             )
         )


### PR DESCRIPTION
Previously only the options for `TokamakEquilibrium` were settable in the GUI. This PR allows the options that only affect `BoutMesh` to also be set.

Also:
* adds all options to the search-bar completer
* gives a more helpful error message when the Jacobian check fails (suggesting increasing `geometry_rtol`)

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [x] Updated `doc/whats-new.md` with a summary of the changes
