### PR TITLE
Monotonic psi spacing

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -5,9 +5,16 @@ What's new
 0.2.2 (unreleased)
 ------------------
 
+### Breaking changes
+
+- Changed function used for determining radial positioning of grid points. Function now
+  guaranteed to be monotonic, so is more robust. However this does change the output
+  slightly compared to previous versions (#64)\
+  By [John Omotani](https://github.com/johnomotani)
+
 ### Bug fixes
 
-- BoutMesh options now settable in GUI (#63)
+- BoutMesh options now settable in GUI (#63)\
   By [John Omotani](https://github.com/johnomotani)
 - Changing settings in File->Preferences caused GUI to crash (#62, fixes #61)\
   By [John Omotani](https://github.com/johnomotani)

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -959,6 +959,12 @@ class PsiContour:
     def distance(self):
         if self._distance is None:
             self._distance = [self.fine_contour.getDistance(p) for p in self]
+            d = numpy.array(self._distance)
+            if not numpy.all(d[1:] - d[:-1] > 0.0):
+                raise ValueError(
+                    f"Distance not monotonically increasing for this contour. "
+                    f"distance={self._distance}"
+                )
         return self._distance
 
     def __iter__(self):

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -413,8 +413,8 @@ class FineContour:
                 "there is no problem with the grid, you could try increasing this "
                 "value."
             ),
-            value_type=float,
-            check_all=is_positive,
+            value_type=(float, NoneType),
+            check_all=is_positive_or_None,
         ),
     )
 
@@ -724,10 +724,13 @@ class FineContour:
 
             self.positions = result
 
-        # Using func_timeout.func_timeout rather than the @func_timeout.func_set_timeout
-        # decorator on the refine method so that we can use self.user_options to set the
-        # length of the timeout.
-        func_timeout.func_timeout(self.user_options.refine_timeout, refine, [self])
+        if self.user_options.refine_timeout is not None:
+            # Using func_timeout.func_timeout rather than the @func_timeout.func_set_timeout
+            # decorator on the refine method so that we can use self.user_options to set the
+            # length of the timeout.
+            func_timeout.func_timeout(self.user_options.refine_timeout, refine, [self])
+        else:
+            refine(self)
 
     def reverse(self):
         if self.distance is not None:

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -408,7 +408,10 @@ class FineContour:
         refine_timeout=WithMeta(
             10.0,
             doc=(
-                "Timeout for refining FineContour objects in seconds. If you get "
+                "Timeout for refining FineContour objects in seconds. Set to None to "
+                "disable the timeout; can be useful for debugging as exceptions may "
+                "get lost due to a separate thread being used to run the refine() "
+                "method with a timeout. If you get "
                 "func_timeout.exceptions.FunctionTimedOut exceptions and you are sure "
                 "there is no problem with the grid, you could try increasing this "
                 "value."

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -3426,10 +3426,21 @@ class Equilibrium:
         smooth across boundaries.
         Function is guaranteed to be monotonic.
         """
+        if grad_lower is not None and (upper - lower) * grad_lower < 0:
+            raise ValueError(
+                f"(upper-lower)={(upper-lower)} and grad_lower={grad_lower} have "
+                f"different signs: should both be increasing or both be decreasing."
+            )
+        if grad_upper is not None and (upper - lower) * grad_upper < 0:
+            raise ValueError(
+                f"(upper-lower)={(upper-lower)} and grad_upper={grad_upper} have "
+                f"different signs: should both be increasing or both be decreasing."
+            )
+
         if grad_lower is None and grad_upper is None:
             return lambda i: lower + (upper - lower) * i / n
         elif grad_upper is None:
-            if grad_lower * n < (upper - lower) * (1.0 + 1.0e-8):
+            if numpy.abs(grad_lower * n) < numpy.abs(upper - lower) * (1.0 + 1.0e-8):
                 # If a constant grid spacing with grad_lower would give a smaller change
                 # than (upper-lower) then we need an increasing grid spacing.
                 # Add a small tolerance because when the decreasing spacing case gets
@@ -3472,7 +3483,7 @@ class Equilibrium:
                     numpy.pi
                 ) / 2.0 * erf(i / numpy.sqrt(a))
         elif grad_lower is None:
-            if grad_upper * n < (upper - lower) * (1.0 + 1.0e-8):
+            if numpy.abs(grad_upper * n) < numpy.abs(upper - lower) * (1.0 + 1.0e-8):
                 # If a constant grid spacing with grad_upper would give a smaller change
                 # than (upper-lower) then we need a grid spacing that increases away
                 # from the upper boundary.
@@ -3516,7 +3527,9 @@ class Equilibrium:
                     numpy.pi
                 ) / 2.0 * erf((i - n) / numpy.sqrt(a))
         else:
-            if 0.5 * (grad_lower + grad_upper) * n < (upper - lower) * (1.0 + 1.0e-8):
+            if 0.5 * numpy.abs(grad_lower + grad_upper) * n < numpy.abs(
+                upper - lower
+            ) * (1.0 + 1.0e-8):
                 # If a linearly varying grid spacing between grad_lower and grad_upper
                 # would give a smaller change than (upper-lower) then we need an
                 # increased average grid spacing.

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -725,9 +725,9 @@ class FineContour:
             self.positions = result
 
         if self.user_options.refine_timeout is not None:
-            # Using func_timeout.func_timeout rather than the @func_timeout.func_set_timeout
-            # decorator on the refine method so that we can use self.user_options to set the
-            # length of the timeout.
+            # Using func_timeout.func_timeout rather than the
+            # @func_timeout.func_set_timeout decorator on the refine method so that we
+            # can use self.user_options to set the length of the timeout.
             func_timeout.func_timeout(self.user_options.refine_timeout, refine, [self])
         else:
             refine(self)

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -1528,29 +1528,29 @@ class MeshRegion:
 
         hy /= self.dy
 
-        def positive_indices(a):
+        def negative_indices(a):
             xinds, yinds = numpy.where(a < 0.0)
             return list(zip(list(xinds), list(yinds)))
 
         if not numpy.all(hy.centre > 0.0):
             raise ValueError(
                 f"hy.centre should always be positive. Negative values found in "
-                f"region '{self.name}' at (x,y) indices {positive_indices(hy.centre)}"
+                f"region '{self.name}' at (x,y) indices {negative_indices(hy.centre)}"
             )
         if not numpy.all(hy.xlow > 0.0):
             raise ValueError(
                 f"hy.xlow should always be positive. Negative values found in "
-                f"region '{self.name}' at (x,y) indices {positive_indices(hy.xlow)}"
+                f"region '{self.name}' at (x,y) indices {negative_indices(hy.xlow)}"
             )
         if not numpy.all(hy.ylow > 0.0):
             raise ValueError(
                 f"hy.ylow should always be positive. Negative values found in "
-                f"region '{self.name}' at (x,y) indices {positive_indices(hy.ylow)}"
+                f"region '{self.name}' at (x,y) indices {negative_indices(hy.ylow)}"
             )
         if not numpy.all(hy.corners > 0.0):
             raise ValueError(
                 f"hy.corners should always be positive. Negative values found in "
-                f"region '{self.name}' at (x,y) indices {positive_indices(hy.corners)}"
+                f"region '{self.name}' at (x,y) indices {negative_indices(hy.corners)}"
             )
         assert numpy.all(hy.xlow > 0.0), "hy.xlow should always be positive"
         assert numpy.all(hy.ylow > 0.0), "hy.ylow should always be positive"

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -1528,7 +1528,30 @@ class MeshRegion:
 
         hy /= self.dy
 
-        assert numpy.all(hy.centre > 0.0), "hy.centre should always be positive"
+        def positive_indices(a):
+            xinds, yinds = numpy.where(a < 0.0)
+            return list(zip(list(xinds), list(yinds)))
+
+        if not numpy.all(hy.centre > 0.0):
+            raise ValueError(
+                f"hy.centre should always be positive. Negative values found in "
+                f"region '{self.name}' at (x,y) indices {positive_indices(hy.centre)}"
+            )
+        if not numpy.all(hy.xlow > 0.0):
+            raise ValueError(
+                f"hy.xlow should always be positive. Negative values found in "
+                f"region '{self.name}' at (x,y) indices {positive_indices(hy.xlow)}"
+            )
+        if not numpy.all(hy.ylow > 0.0):
+            raise ValueError(
+                f"hy.ylow should always be positive. Negative values found in "
+                f"region '{self.name}' at (x,y) indices {positive_indices(hy.ylow)}"
+            )
+        if not numpy.all(hy.corners > 0.0):
+            raise ValueError(
+                f"hy.corners should always be positive. Negative values found in "
+                f"region '{self.name}' at (x,y) indices {positive_indices(hy.corners)}"
+            )
         assert numpy.all(hy.xlow > 0.0), "hy.xlow should always be positive"
         assert numpy.all(hy.ylow > 0.0), "hy.ylow should always be positive"
         assert numpy.all(hy.corners > 0.0), "hy.corners should always be positive"

--- a/hypnotoad/test_suite/test_equilibrium.py
+++ b/hypnotoad/test_suite/test_equilibrium.py
@@ -634,18 +634,20 @@ class TestEquilibrium:
         assert intersect.R == tight_approx(1.0)
         assert intersect.Z == tight_approx(1.0)
 
-    def test_getPolynomialGridFuncGradLowerDecreasing(self, eq):
+    @pytest.mark.parametrize(
+        ["grad_lower", "lower", "upper"], [[0.2, 0.4, 2.0], [-0.2, 2.0, 0.4]]
+    )
+    def test_getPolynomialGridFuncGradLowerDecreasing(
+        self, eq, grad_lower, lower, upper
+    ):
         # Test getPolynomialGridFunc() with grad_lower set so that it needs to decrease
         # the average spacing
-        grad_lower = 0.2
-        lower = 0.4
-        upper = 2.0
         N = 10.0
         f = eq.getPolynomialGridFunc(N, lower, upper, grad_lower=grad_lower)
         # f(0) = lower
         assert f(0.0) == tight_approx(lower)
         # f(N) = upper
-        assert f(N) == pytest.approx(upper, rel=2.0e-12, abs=1.0e-13)
+        assert f(N) == pytest.approx(upper, rel=8.0e-12, abs=1.0e-13)
         # for i<<1, df/di = grad_lower
         itest = 1.0e-3
         assert (f(itest) - f(0.0)) / itest == pytest.approx(grad_lower, abs=1.0e-5)
@@ -654,12 +656,14 @@ class TestEquilibrium:
             0.0, abs=1.0e-5
         )
 
-    def test_getPolynomialGridFuncGradLowerIncreasing(self, eq):
+    @pytest.mark.parametrize(
+        ["grad_lower", "lower", "upper"], [[0.02, 0.4, 2.0], [-0.02, 2.0, 0.4]]
+    )
+    def test_getPolynomialGridFuncGradLowerIncreasing(
+        self, eq, grad_lower, lower, upper
+    ):
         # Test getPolynomialGridFunc() with grad_lower set so that it needs to increase
         # the average spacing
-        grad_lower = 0.02
-        lower = 0.4
-        upper = 2.0
         N = 10.0
         f = eq.getPolynomialGridFunc(N, lower, upper, grad_lower=grad_lower)
         # f(0) = lower
@@ -674,12 +678,14 @@ class TestEquilibrium:
             0.0, abs=1.0e-5
         )
 
-    def test_getPolynomialGridFuncGradUpperDecreasing(self, eq):
+    @pytest.mark.parametrize(
+        ["grad_upper", "lower", "upper"], [[0.5, 0.4, 2.0], [-0.5, 2.0, 0.4]]
+    )
+    def test_getPolynomialGridFuncGradUpperDecreasing(
+        self, eq, grad_upper, lower, upper
+    ):
         # Test getPolynomialGridFunc() with grad_upper set so that it needs to decrease
         # the average spacing
-        grad_upper = 0.5
-        lower = 0.4
-        upper = 2.0
         N = 10.0
         f = eq.getPolynomialGridFunc(N, lower, upper, grad_upper=grad_upper)
         # f(0) = lower
@@ -694,12 +700,14 @@ class TestEquilibrium:
             f(N) - 2.0 * f(N - itest) + f(N - 2.0 * itest)
         ) / itest ** 2 == pytest.approx(0.0, abs=1.0e-5)
 
-    def test_getPolynomialGridFuncGradUpperIncreasing(self, eq):
+    @pytest.mark.parametrize(
+        ["grad_upper", "lower", "upper"], [[0.1, 0.4, 2.0], [-0.1, 2.0, 0.4]]
+    )
+    def test_getPolynomialGridFuncGradUpperIncreasing(
+        self, eq, grad_upper, lower, upper
+    ):
         # Test getPolynomialGridFunc() with grad_upper set so that it needs to increase
         # the average spacing
-        grad_upper = 0.1
-        lower = 0.4
-        upper = 2.0
         N = 10.0
         f = eq.getPolynomialGridFunc(N, lower, upper, grad_upper=grad_upper)
         # f(0) = lower
@@ -714,13 +722,15 @@ class TestEquilibrium:
             f(N) - 2.0 * f(N - itest) + f(N - 2.0 * itest)
         ) / itest ** 2 == pytest.approx(0.0, abs=1.0e-5)
 
-    def test_getPolynomialGridFuncGradBothDecreasing(self, eq):
+    @pytest.mark.parametrize(
+        ["grad_lower", "grad_upper", "lower", "upper"],
+        [[0.4, 0.2, 0.4, 2.0], [-0.4, -0.2, 2.0, 0.4]],
+    )
+    def test_getPolynomialGridFuncGradBothDecreasing(
+        self, eq, grad_lower, grad_upper, lower, upper
+    ):
         # Test getPolynomialGridFunc() with grad_lower and grad_upper set so that it
         # needs to decrease the average spacing
-        grad_lower = 0.4
-        grad_upper = 0.2
-        lower = 0.4
-        upper = 2.0
         N = 10.0
         f = eq.getPolynomialGridFunc(
             N, lower, upper, grad_lower=grad_lower, grad_upper=grad_upper
@@ -743,7 +753,13 @@ class TestEquilibrium:
             f(N) - 2.0 * f(N - itest) + f(N - 2.0 * itest)
         ) / itest ** 2 == pytest.approx(0.0, abs=1.0e-5)
 
-    def test_getPolynomialGridFuncGradBothIncreasing(self, eq):
+    @pytest.mark.parametrize(
+        ["grad_lower", "grad_upper", "lower", "upper"],
+        [[0.2, 0.1, 0.4, 2.0], [-0.2, -0.1, 2.0, 0.4]],
+    )
+    def test_getPolynomialGridFuncGradBothIncreasing(
+        self, eq, grad_lower, grad_upper, lower, upper
+    ):
         # Test getPolynomialGridFunc() with grad_lower and grad_upper set so that it
         # needs to increase the average spacing
         grad_lower = 0.2

--- a/hypnotoad/test_suite/test_equilibrium.py
+++ b/hypnotoad/test_suite/test_equilibrium.py
@@ -634,8 +634,30 @@ class TestEquilibrium:
         assert intersect.R == tight_approx(1.0)
         assert intersect.Z == tight_approx(1.0)
 
-    def test_getPolynomialGridFuncGradLower(self, eq):
+    def test_getPolynomialGridFuncGradLowerDecreasing(self, eq):
+        # Test getPolynomialGridFunc() with grad_lower set so that it needs to decrease
+        # the average spacing
         grad_lower = 0.2
+        lower = 0.4
+        upper = 2.0
+        N = 10.0
+        f = eq.getPolynomialGridFunc(N, lower, upper, grad_lower=grad_lower)
+        # f(0) = lower
+        assert f(0.0) == tight_approx(lower)
+        # f(N) = upper
+        assert f(N) == pytest.approx(upper, rel=2.0e-12, abs=1.0e-13)
+        # for i<<1, df/di = grad_lower
+        itest = 1.0e-3
+        assert (f(itest) - f(0.0)) / itest == pytest.approx(grad_lower, abs=1.0e-5)
+        # for i<<1, d2f/di2 = 0
+        assert (f(0.0) - 2.0 * f(itest) + f(2.0 * itest)) / itest ** 2 == pytest.approx(
+            0.0, abs=1.0e-5
+        )
+
+    def test_getPolynomialGridFuncGradLowerIncreasing(self, eq):
+        # Test getPolynomialGridFunc() with grad_lower set so that it needs to increase
+        # the average spacing
+        grad_lower = 0.02
         lower = 0.4
         upper = 2.0
         N = 10.0
@@ -652,7 +674,29 @@ class TestEquilibrium:
             0.0, abs=1.0e-5
         )
 
-    def test_getPolynomialGridFuncGradUpper(self, eq):
+    def test_getPolynomialGridFuncGradUpperDecreasing(self, eq):
+        # Test getPolynomialGridFunc() with grad_upper set so that it needs to decrease
+        # the average spacing
+        grad_upper = 0.5
+        lower = 0.4
+        upper = 2.0
+        N = 10.0
+        f = eq.getPolynomialGridFunc(N, lower, upper, grad_upper=grad_upper)
+        # f(0) = lower
+        assert f(0.0) == tight_approx(lower)
+        # f(N) = upper
+        assert f(N) == tight_approx(upper)
+        # for N-i<<1, df/di = grad_upper
+        itest = 1.0e-4
+        assert (f(N) - f(N - itest)) / itest == pytest.approx(grad_upper, abs=1.0e-5)
+        # for N-i<<1, d2f/di2 = 0
+        assert (
+            f(N) - 2.0 * f(N - itest) + f(N - 2.0 * itest)
+        ) / itest ** 2 == pytest.approx(0.0, abs=1.0e-5)
+
+    def test_getPolynomialGridFuncGradUpperIncreasing(self, eq):
+        # Test getPolynomialGridFunc() with grad_upper set so that it needs to increase
+        # the average spacing
         grad_upper = 0.1
         lower = 0.4
         upper = 2.0
@@ -670,7 +714,38 @@ class TestEquilibrium:
             f(N) - 2.0 * f(N - itest) + f(N - 2.0 * itest)
         ) / itest ** 2 == pytest.approx(0.0, abs=1.0e-5)
 
-    def test_getPolynomialGridFuncGradBoth(self, eq):
+    def test_getPolynomialGridFuncGradBothDecreasing(self, eq):
+        # Test getPolynomialGridFunc() with grad_lower and grad_upper set so that it
+        # needs to decrease the average spacing
+        grad_lower = 0.4
+        grad_upper = 0.2
+        lower = 0.4
+        upper = 2.0
+        N = 10.0
+        f = eq.getPolynomialGridFunc(
+            N, lower, upper, grad_lower=grad_lower, grad_upper=grad_upper
+        )
+        # f(0) = lower
+        assert f(0.0) == tight_approx(lower)
+        # f(N) = upper
+        assert f(N) == pytest.approx(upper, rel=1.0e-10, abs=1.0e-13)
+        # for i<<1, df/di = grad_lower
+        itest = 1.0e-5
+        assert (f(itest) - f(0.0)) / itest == pytest.approx(grad_lower, abs=1.0e-5)
+        # for i<<1, d2f/di2 = 0
+        assert (f(0.0) - 2.0 * f(itest) + f(2.0 * itest)) / itest ** 2 == pytest.approx(
+            0.0, abs=1.0e-5
+        )
+        # for N-i<<1, df/di = grad_upper
+        assert (f(N) - f(N - itest)) / itest == pytest.approx(grad_upper, abs=1.0e-5)
+        # for N-i<<1, d2f/di2 = 0
+        assert (
+            f(N) - 2.0 * f(N - itest) + f(N - 2.0 * itest)
+        ) / itest ** 2 == pytest.approx(0.0, abs=1.0e-5)
+
+    def test_getPolynomialGridFuncGradBothIncreasing(self, eq):
+        # Test getPolynomialGridFunc() with grad_lower and grad_upper set so that it
+        # needs to increase the average spacing
         grad_lower = 0.2
         grad_upper = 0.1
         lower = 0.4

--- a/hypnotoad/test_suite/test_equilibrium.py
+++ b/hypnotoad/test_suite/test_equilibrium.py
@@ -487,6 +487,8 @@ class TestContour:
         c.startInd = 2
         c.endInd = len(c) - 2
         n = c.endInd - c.startInd + 1
+        c.extend_lower = 2
+        c.extend_upper = 2
 
         f = c.contourSfunc()
 
@@ -501,13 +503,15 @@ class TestContour:
         c1 = testcontour.c
         c1.startInd = 2
         c1.endInd = len(c1) - 2
-        n = c1.endInd - c1.startInd
+        n1 = c1.endInd - c1.startInd
+        c1.extend_lower = 2
+        c1.extend_upper = 2
+        npoints1 = len(c1)
 
-        npoints = len(c1)
         r = testcontour.r
         R0 = testcontour.R0
         Z0 = testcontour.Z0
-        theta = numpy.linspace(0.0, 1.5 * numpy.pi, npoints)
+        theta = numpy.linspace(0.0, 1.5 * numpy.pi, 37)
 
         R = R0 + r * numpy.cos(theta)
         Z = Z0 + r * numpy.sin(theta)
@@ -520,6 +524,10 @@ class TestContour:
         )
         c2.startInd = 2
         c2.endInd = len(c2) - 1
+        n2 = c2.endInd - c2.startInd
+        c2.extend_lower = 2
+        c2.extend_upper = 1
+        npoints2 = len(c2)
 
         c_list = [c1, c2]
         sfunc_list = []
@@ -534,11 +542,11 @@ class TestContour:
             sfunc_list.append(lambda i: sfunc_orig(i) - 3.0)
 
         # notice we check that the first test *fails*
-        assert not sfunc_list[0](float(n)) == pytest.approx(
-            n / (npoints - 1.0) * numpy.pi * r - 3.0, abs=1.0e-6
+        assert not sfunc_list[0](float(n1)) == pytest.approx(
+            n1 / (npoints1 - 1.0) * numpy.pi * r - 3.0, abs=1.0e-6
         )
-        assert sfunc_list[1](float(n)) == pytest.approx(
-            n / (npoints - 1.0) * 1.5 * numpy.pi * r - 3.0, abs=4.0e-6
+        assert sfunc_list[1](float(n2)) == pytest.approx(
+            n2 / (npoints2 - 1.0) * 1.5 * numpy.pi * r - 3.0, abs=4.0e-6
         )
 
         sfunc_list2 = []
@@ -552,11 +560,11 @@ class TestContour:
         for c in c_list:
             sfunc_list2.append(shift_sfunc(c))
 
-        assert sfunc_list2[0](float(n)) == pytest.approx(
-            n / (npoints - 1.0) * numpy.pi * r - 3.0, abs=1.0e-6
+        assert sfunc_list2[0](float(n1)) == pytest.approx(
+            n1 / (npoints1 - 1.0) * numpy.pi * r - 3.0, abs=1.0e-6
         )
-        assert sfunc_list2[1](float(n)) == pytest.approx(
-            n / (npoints - 1.0) * 1.5 * numpy.pi * r - 3.0, abs=4.0e-6
+        assert sfunc_list2[1](float(n2)) == pytest.approx(
+            n2 / (npoints2 - 1.0) * 1.5 * numpy.pi * r - 3.0, abs=4.0e-6
         )
 
     def test_interpSSperp(self, testcontour):
@@ -1105,6 +1113,8 @@ class TestEquilibriumRegion:
         )
 
         eqReg.startInd = intersect_index
+        eqReg.extend_lower = intersect_index
+        eqReg.extend_upper = 1
 
         d = eqReg.totalDistance()
 
@@ -1148,6 +1158,8 @@ class TestEquilibriumRegion:
         )
 
         eqReg.startInd = intersect_index
+        eqReg.extend_lower = intersect_index
+        eqReg.extend_upper = 1
 
         d = eqReg.totalDistance()
 


### PR DESCRIPTION
Makes the function returned by `Equilibrium.getPolynomialGridFunc()`, which is used to set the psi-values of the grid points, guaranteed to be monotonic. This makes grid generation more robust, avoiding errors due to overshoots.

Technically a breaking change, since this will make hypnotoad produce a different output than previous versions from the same input. The difference should be small though, and we are still pre-1.0 so it does not seem worth adding complexity to allow preserving previous behaviour - it is still possible to use an old version, and the version used to produce a grid file is saved in the grid file.

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [x] Tests added/updated
- [x] Updated `doc/whats-new.md` with a summary of the changes
