### PR TITLE
Fix failure when using target_poloidal_spacing_length with y_boundary_guards>0

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -7,6 +7,9 @@ What's new
 
 ### Bug fixes
 
+- Failure when target_poloidal_spacing_length set to number (rather than the
+  default None) when y_boundary_guards is non-zero (#64)\
+  By [John Omotani](https://github.com/johnomotani)
 - BoutMesh options now settable in GUI (#63)
   By [John Omotani](https://github.com/johnomotani)
 - Changing settings in File->Preferences caused GUI to crash (#62, fixes #61)\

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -2955,14 +2955,44 @@ class EquilibriumRegion(PsiContour):
                     > -self.user_options.sfunc_checktol
                 ), "gradient of non-singular part should be positive at end"
 
-            return (
-                lambda i: a * numpy.sqrt(i / N_norm)
-                - b * numpy.sqrt((N - i) / N_norm)
-                + c
-                + d * i / N_norm
-                + e * (i / N_norm) ** 2
-                + f * (i / N_norm) ** 3
-            )
+            if a == 0.0 and b == 0.0:
+                # No sqrt parts, special case in case extrapolation at either
+                # end is wanted (where sqrt would give NaN)
+                return (
+                    lambda i: c
+                    + d * i / N_norm
+                    + e * (i / N_norm) ** 2
+                    + f * (i / N_norm) ** 3
+                )
+            elif a == 0.0:
+                # Only upper sqrt part, special case in case extrapolation at
+                # either end is wanted (where sqrt would give NaN)
+                return (
+                    lambda i: -b * numpy.sqrt((N - i) / N_norm)
+                    + c
+                    + d * i / N_norm
+                    + e * (i / N_norm) ** 2
+                    + f * (i / N_norm) ** 3
+                )
+            elif b == 0.0:
+                # Only lower sqrt part, special case in case extrapolation at
+                # either end is wanted (where sqrt would give NaN)
+                return (
+                    lambda i: a * numpy.sqrt(i / N_norm)
+                    + c
+                    + d * i / N_norm
+                    + e * (i / N_norm) ** 2
+                    + f * (i / N_norm) ** 3
+                )
+            else:
+                return (
+                    lambda i: a * numpy.sqrt(i / N_norm)
+                    - b * numpy.sqrt((N - i) / N_norm)
+                    + c
+                    + d * i / N_norm
+                    + e * (i / N_norm) ** 2
+                    + f * (i / N_norm) ** 3
+                )
 
 
 class Equilibrium:

--- a/hypnotoad/test_suite/test_equilibrium.py
+++ b/hypnotoad/test_suite/test_equilibrium.py
@@ -764,6 +764,9 @@ class TestEquilibriumRegion:
         # for i<<1, f ~ b_lower*i/N_norm
         itest = 0.01
         assert f(itest) == pytest.approx(b_lower * itest / N_norm, abs=1.0e-5)
+        # Check we can extrapolate at upper end
+        itest = N + 0.01
+        assert numpy.isfinite(f(itest))
 
     def test_getSqrtPoloidalDistanceFuncBUpper(self, eqReg):
         b_upper = 0.01
@@ -778,6 +781,9 @@ class TestEquilibriumRegion:
         # for (N-i)<<1, f ~ L - b_upper*(N-i)/N_norm
         itest = N - 0.01
         assert f(itest) == pytest.approx(L - b_upper * (N - itest) / N_norm, abs=1.0e-5)
+        # Check we can extrapolate at lower end
+        itest = -0.01
+        assert numpy.isfinite(f(itest))
 
     def test_getSqrtPoloidalDistanceFuncBBoth(self, eqReg):
         b_lower = 0.1
@@ -795,8 +801,14 @@ class TestEquilibriumRegion:
         # for i<<1, f ~ b_lower*i/N_norm
         itest = 0.01
         assert f(itest) == pytest.approx(b_lower * itest / N_norm, abs=1.0e-5)
+        # Check we can extrapolate at lower end
+        itest = -0.01
+        assert f(itest) == pytest.approx(b_lower * itest / N_norm, abs=1.0e-5)
         # for (N-i)<<1, f ~ L - b_upper*(N-i)/N_norm
         itest = N - 0.01
+        assert f(itest) == pytest.approx(L - b_upper * (N - itest) / N_norm, abs=1.0e-5)
+        # Check we can extrapolate at upper end
+        itest = N + 0.01
         assert f(itest) == pytest.approx(L - b_upper * (N - itest) / N_norm, abs=1.0e-5)
 
     def test_getSqrtPoloidalDistanceFuncBothLower(self, eqReg):
@@ -818,6 +830,9 @@ class TestEquilibriumRegion:
             2.0 * a_lower * numpy.sqrt(itest / N_norm) + b_lower * itest / N_norm,
             abs=1.0e-5,
         )
+        # Check we can extrapolate at upper end
+        itest = N + 0.01
+        assert numpy.isfinite(f(itest))
 
     def test_getSqrtPoloidalDistanceFuncBothUpper(self, eqReg):
         b_upper = 0.01
@@ -832,6 +847,89 @@ class TestEquilibriumRegion:
         assert f(0.0) == tight_approx(0.0)
         # f(N) = L
         assert f(N) == tight_approx(L)
+        # for (N-i)<<1, f ~ L - 2*a_upper*sqrt((N-i)/N_norm) - b_upper*(N-i)/N_norm
+        itest = N - 0.01
+        assert f(itest) == pytest.approx(
+            L
+            - 2.0 * a_upper * numpy.sqrt((N - itest) / N_norm)
+            - b_upper * (N - itest) / N_norm,
+            abs=1.0e-5,
+        )
+        # Check we can extrapolate at lower end
+        itest = -0.01
+        assert numpy.isfinite(f(itest))
+
+    def test_getSqrtPoloidalDistanceFuncALowerBBoth(self, eqReg):
+        b_lower = 0.01
+        a_lower = 0.05
+        b_upper = 0.2
+        L = 2.0
+        L = 2.0
+        N = 10.0
+        N_norm = 1
+        f = eqReg.getSqrtPoloidalDistanceFunc(
+            L,
+            N,
+            N_norm,
+            b_lower=b_lower,
+            a_lower=a_lower,
+            b_upper=b_upper,
+        )
+        # f(0) = 0
+        assert f(0.0) == tight_approx(0.0)
+        # f(N) = L
+        assert f(N) == tight_approx(L)
+        # for i<<1, f ~ 2*a_lower*sqrt(i/N_norm) + b_lower*i/N_norm
+        itest = 0.01
+        assert f(itest) == pytest.approx(
+            2.0 * a_lower * numpy.sqrt(itest / N_norm) + b_lower * itest / N_norm,
+            abs=1.0e-5,
+        )
+        # for (N-i)<<1, f ~ L - b_upper*(N-i)/N_norm
+        itest = N - 0.01
+        assert f(itest) == pytest.approx(
+            L - b_upper * (N - itest) / N_norm,
+            abs=1.0e-5,
+        )
+        # Check we can also extrapolate past the end
+        itest = N + 0.01
+        assert f(itest) == pytest.approx(
+            L - b_upper * (N - itest) / N_norm,
+            abs=1.0e-5,
+        )
+
+    def test_getSqrtPoloidalDistanceFuncAUpperBBoth(self, eqReg):
+        b_lower = 0.01
+        b_upper = 0.2
+        a_upper = 0.07
+        L = 2.0
+        L = 2.0
+        N = 10.0
+        N_norm = 1
+        f = eqReg.getSqrtPoloidalDistanceFunc(
+            L,
+            N,
+            N_norm,
+            b_lower=b_lower,
+            b_upper=b_upper,
+            a_upper=a_upper,
+        )
+        # f(0) = 0
+        assert f(0.0) == tight_approx(0.0)
+        # f(N) = L
+        assert f(N) == tight_approx(L)
+        # for i<<1, f ~ b_lower*i/N_norm
+        itest = 0.01
+        assert f(itest) == pytest.approx(
+            b_lower * itest / N_norm,
+            abs=1.0e-5,
+        )
+        # Check we can also extrapolate past the end
+        itest = -0.01
+        assert f(itest) == pytest.approx(
+            b_lower * itest / N_norm,
+            abs=1.0e-5,
+        )
         # for (N-i)<<1, f ~ L - 2*a_upper*sqrt((N-i)/N_norm) - b_upper*(N-i)/N_norm
         itest = N - 0.01
         assert f(itest) == pytest.approx(


### PR DESCRIPTION
Previously hypnotoad would fail if `target_poloidal_spacing` was set to a number rather than `None` when `y_boundary_guards` was greater than 0. This was caused by a bug in extrapolation in the spacing function returned by `EquilibriumRegion.getSqrtPoloidalDistanceFunc()` for this case. This PR adds unit tests that find the underlying bug, and fixes it.

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [x] Tests added
- [x] Updated `doc/whats-new.md` with a summary of the changes
