### PR TITLE
Create a UUID for each grid file

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -5,6 +5,11 @@ What's new
 0.2.2 (unreleased)
 ------------------
 
+### New features
+
+- UUID unique identifier saved into each grid file (#67, closes #66)\
+  By [John Omotani](https://github.com/johnomotani)
+
 ### Bug fixes
 
 - BoutMesh options now settable in GUI (#63)

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -2517,6 +2517,15 @@ class BoutMesh(Mesh):
         from boututils.datafile import DataFile
 
         with DataFile(filename, create=True, format="NETCDF4") as f:
+            # Save unique ID for grid file
+            import uuid
+
+            id_str = str(uuid.uuid1())
+            id_numpy_array = numpy.array(list(id_str), dtype="S1")
+            id_bout_array = BoutArray(
+                id_numpy_array, attributes={"bout_type": "string"}
+            )
+            f.write("grid_id", id_bout_array)
             f.write("nx", self.nx)
             # ny for BOUT++ excludes boundary guard cells
             f.write("ny", self.ny_noguards)

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -2520,12 +2520,7 @@ class BoutMesh(Mesh):
             # Save unique ID for grid file
             import uuid
 
-            id_str = str(uuid.uuid1())
-            id_numpy_array = numpy.array(list(id_str), dtype="S1")
-            id_bout_array = BoutArray(
-                id_numpy_array, attributes={"bout_type": "string"}
-            )
-            f.write("grid_id", id_bout_array)
+            f.write_file_attribute("grid_id", str(uuid.uuid1()))
             f.write("nx", self.nx)
             # ny for BOUT++ excludes boundary guard cells
             f.write("ny", self.ny_noguards)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        "boututils~=0.1.4",
+        "boututils~=0.1.7",
         "func_timeout~=4.3",
         "matplotlib~=3.2",
         "netCDF4~=1.5",


### PR DESCRIPTION
Use the Python uuid module to create a UUID unique identifier for each grid file, and save into the grid file as `grid_id`.

Need to check the `grid_id` can be read by BOUT++ - it should be read from the grid file and saved to the BOUT++ output to ensure we know what grid file was used for a simulation. Maybe add as part of https://github.com/boutproject/BOUT-dev/pull/2149 / https://github.com/boutproject/BOUT-dev/pull/2192?

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [x] Closes #66
- [x] Updated `doc/whats-new.md` with a summary of the changes