### PR TITLE
Write strings as file attributes

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -7,6 +7,8 @@ What's new
 
 ### Bug fixes
 
+- String outputs written as file attributes rather than variables (#69, fixes #68)\
+  By [John Omotani](https://github.com/johnomotani)
 - BoutMesh options now settable in GUI (#63)
   By [John Omotani](https://github.com/johnomotani)
 - Changing settings in File->Preferences caused GUI to crash (#62, fixes #61)\

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -2666,16 +2666,18 @@ class BoutMesh(Mesh):
             # BOUT++ ParallelTransform that metrics are compatible with
             if self.user_options.shiftedmetric:
                 # Toroidal coordinates with shifts to calculate parallel derivatives
-                f.write("parallel_transform", "shiftedmetric")
+                f.write_file_attribute("parallel_transform", "shiftedmetric")
             else:
                 # Field-aligned coordinates
-                f.write("parallel_transform", "identity")
+                f.write_file_attribute("parallel_transform", "identity")
 
-            f.write("hypnotoad_inputs", self.equilibrium._getOptionsAsString())
-            f.write("hypnotoad_version", self.version)
+            f.write_file_attribute(
+                "hypnotoad_inputs", self.equilibrium._getOptionsAsString()
+            )
+            f.write_file_attribute("hypnotoad_version", self.version)
             if self.git_hash is not None:
-                f.write("hypnotoad_git_hash", self.git_hash)
-                f.write(
+                f.write_file_attribute("hypnotoad_git_hash", self.git_hash)
+                f.write_file_attribute(
                     "hypnotoad_git_diff",
                     self.git_diff if self.git_diff is not None else "",
                 )

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        "boututils~=0.1.4",
+        "boututils~=0.1.7",
         "func_timeout~=4.3",
         "matplotlib~=3.2",
         "netCDF4~=1.5",


### PR DESCRIPTION
Lets them be read by BOUT++'s `Mesh::get()` method.

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [x] Closes #68
- [x] Updated `doc/whats-new.md` with a summary of the changes
