### PR TITLE
Save geqdsk input to grid file

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -14,6 +14,9 @@ What's new
 
 ### New features
 
+- When grid file is created from a geqdsk input, save the filename, and the
+  contents of the geqdsk file to the grid file (#71, closes #70)\
+  By [John Omotani](https://github.com/johnomotani)
 - UUID unique identifier saved into each grid file (#67, closes #66)\
   By [John Omotani](https://github.com/johnomotani)
 

--- a/hypnotoad/cases/tokamak.py
+++ b/hypnotoad/cases/tokamak.py
@@ -1591,7 +1591,8 @@ def read_geqdsk(
     filehandle.seek(0)
     # read file as a single string and store in result
     result.geqdsk_input = filehandle.read()
-    # also save filename
-    result.geqdsk_filename = filehandle.name
+    # also save filename, if it exists
+    if hasattr(filehandle, "name"):
+        result.geqdsk_filename = filehandle.name
 
     return result

--- a/hypnotoad/cases/tokamak.py
+++ b/hypnotoad/cases/tokamak.py
@@ -1572,7 +1572,7 @@ def read_geqdsk(
         # fpol constant in SOL
         fpol = np.concatenate([fpol, np.full(psiSOL.shape, fpol[-1])])
 
-    return TokamakEquilibrium(
+    result = TokamakEquilibrium(
         R1D,
         Z1D,
         psi2D,
@@ -1584,3 +1584,14 @@ def read_geqdsk(
         settings=settings,
         nonorthogonal_settings=nonorthogonal_settings,
     )
+
+    # Store geqdsk input as a string in the TokamakEquilibrium object so we can save it
+    # in BoutMesh.writeGridFile
+    # reset to beginning of file
+    filehandle.seek(0)
+    # read file as a single string and store in result
+    result.geqdsk_input = filehandle.read()
+    # also save filename
+    result.geqdsk_filename = filehandle.name
+
+    return result

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -2709,6 +2709,24 @@ class BoutMesh(Mesh):
                     self.git_diff if self.git_diff is not None else "",
                 )
 
+            if hasattr(self.equilibrium, "geqdsk_filename"):
+                # If grid was created from a geqdsk file, save the file name
+                f.write_file_attribute(
+                    "hypnotoad_geqdsk_filename", self.equilibrium.geqdsk_filename
+                )
+            if hasattr(self.equilibrium, "geqdsk_input"):
+                # If grid was created from a geqdsk file, save the file contents
+                #
+                # Write as string variable and not attribute because the string will be
+                # long and attributes are printed by 'ncdump -h' or by ncdump when
+                # looking at a different variable, which would be inconvenient. It is
+                # not likely that we need to load the geqdsk file contents in BOUT++, so
+                # no reason to save as an attribute.
+                f.write(
+                    "hypnotoad_input_geqdsk_file_contents",
+                    self.equilibrium.geqdsk_input,
+                )
+
     def plot2D(self, f, title=None):
         from matplotlib import pyplot
 

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -2698,9 +2698,13 @@ class BoutMesh(Mesh):
                 # Field-aligned coordinates
                 f.write_file_attribute("parallel_transform", "identity")
 
-            f.write_file_attribute(
-                "hypnotoad_inputs", self.equilibrium._getOptionsAsString()
-            )
+            # Save hypnotoad_inputs as a variable rather than an attribute because they
+            # are long and attributes are printed by 'ncdump -h' or by ncdump when
+            # looking at a different variable, which would be inconvenient. It is not
+            # likely that we need to load the hypnotoad inputs in BOUT++, so no reason
+            # to save as an attribute.
+            f.write("hypnotoad_inputs", self.equilibrium._getOptionsAsString())
+
             f.write_file_attribute("hypnotoad_version", self.version)
             if self.git_hash is not None:
                 f.write_file_attribute("hypnotoad_git_hash", self.git_hash)


### PR DESCRIPTION
When creating a grid from a geqdsk file, saves the geqdsk filename and file contents as strings in the grid file.

The file contents are saved as a string variable rather than a string file-attribute (like other strings) because the string is long, and clutters `ncdump` output if it is saved as an attribute. The reason for saving as attributes is mainly to make it easier to read with the current BOUT++ file I/O, and we are unlikely to want the geqdsk file contents in BOUT++. For the same reason, converts `hypnotoad_inputs` back to a string variable instead of a string file-attribute.

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [x] Closes #70
- [ ] Tests added
- [x] Updated `doc/whats-new.md` with a summary of the changes
