### PR TITLE
Flag to start pdb when running hypnotoad_geqdsk

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -14,6 +14,9 @@ What's new
 
 ### New features
 
+- Command line argument for hypnotoad_geqdsk to call pdb.set_trace() to make it
+  easier to debug exceptions with pdb (#72)\
+  By [John Omotani](https://github.com/johnomotani)
 - When grid file is created from a geqdsk input, save the filename, and the
   contents of the geqdsk file to the grid file (#71, closes #70)\
   By [John Omotani](https://github.com/johnomotani)

--- a/hypnotoad/scripts/hypnotoad_geqdsk.py
+++ b/hypnotoad/scripts/hypnotoad_geqdsk.py
@@ -17,6 +17,7 @@ def main():
     parser = ArgumentParser()
     parser.add_argument("filename")
     parser.add_argument("inputfile", nargs="?", default=None)
+    parser.add_argument("--pdb", action="store_true", default=False)
     args = parser.parse_args()
 
     filename = args.filename
@@ -30,6 +31,11 @@ def main():
         options = {}
 
     from ..cases import tokamak
+
+    if args.pdb:
+        import pdb
+
+        pdb.set_trace()
 
     with open(filename, "rt") as fh:
         eq = tokamak.read_geqdsk(fh, settings=options, nonorthogonal_settings=options)


### PR DESCRIPTION
Scripts written for use with entry-points in setup.py do not seem to work with e.g. '`python -m pdb hypnotoad_geqdsk`. As a workaround, add a command-line argument `--pdb` to start pdb with pdb.set_trace().

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [x] Updated `doc/whats-new.md` with a summary of the changes
