### PR TITLE
Check for unsupported options in input files

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -14,6 +14,9 @@ What's new
 
 ### New features
 
+- Check for unrecognised options in input files and raise an error if any are found
+  (#76)\
+  By [John Omotani](https://github.com/johnomotani)
 - EquilibriumRegion.getSqrtPoloidalDistanceFunc() upgraded to ensure that when
   it extrapolates the distance function is always monotonic. This is used when
   y_boundary_guards is greater than 0 (#73)\

--- a/hypnotoad/scripts/hypnotoad_geqdsk.py
+++ b/hypnotoad/scripts/hypnotoad_geqdsk.py
@@ -31,6 +31,21 @@ def main():
         options = {}
 
     from ..cases import tokamak
+    from ..core.mesh import BoutMesh
+
+    possible_options = (
+        [opt for opt in tokamak.TokamakEquilibrium.user_options_factory.defaults]
+        + [
+            opt
+            for opt in tokamak.TokamakEquilibrium.nonorthogonal_options_factory.defaults
+        ]
+        + [opt for opt in BoutMesh.user_options_factory.defaults]
+    )
+    unused_options = [opt for opt in options if opt not in possible_options]
+    if unused_options != []:
+        raise ValueError(
+            f"There were options in the input file that are not used: {unused_options}"
+        )
 
     if args.pdb:
         import pdb
@@ -55,8 +70,6 @@ def main():
             warnings.warn(str(err))
 
     # Create the mesh
-
-    from ..core.mesh import BoutMesh
 
     mesh = BoutMesh(eq, options)
     mesh.calculateRZ()


### PR DESCRIPTION
If an unrecognised option is present, it is either a typo or an option that was removed. In either case, the input is probably not correct, so raise an error instead of ignoring in `hypnotoad_geqdsk` and `hypnotoad-gui`.

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [x] Updated `doc/whats-new.md` with a summary of the changes
