### PR TITLE
Enable dct interpolation for TokamakEquilibrum

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -14,6 +14,9 @@ What's new
 
 ### New features
 
+- Enable DCT interpolation scheme in TokamakEquilibrum, can be selected with new option
+  psi_interpolation_method (#77)\
+  By [John Omotani](https://github.com/johnomotani)
 - EquilibriumRegion.getSqrtPoloidalDistanceFunc() upgraded to ensure that when
   it extrapolates the distance function is always monotonic. This is used when
   y_boundary_guards is greater than 0 (#73)\

--- a/hypnotoad/cases/tokamak.py
+++ b/hypnotoad/cases/tokamak.py
@@ -48,7 +48,7 @@ class TokamakEquilibrium(Equilibrium):
                 "'dct' for a discrete cosine transform."
             ),
             value_type=str,
-            check_all=lambda val: val in ["spline", "dct"],
+            allowed=["spline", "dct"],
         ),
         nx_core=WithMeta(
             5,

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -3232,17 +3232,42 @@ class Equilibrium:
 
         self._dct = DCT_2D(R, Z, psiRZ)
 
-        self.psi = lambda R, Z: self._dct(R, Z)
+        self._psi = lambda R, Z: self._dct(R, Z)
         modGradpsiSquared = (
             lambda R, Z: self._dct.ddR(R, Z) ** 2 + self._dct.ddZ(R, Z) ** 2
         )
-        self.f_R = lambda R, Z: self._dct.ddR(R, Z) / modGradpsiSquared(R, Z)
-        self.f_Z = lambda R, Z: self._dct.ddZ(R, Z) / modGradpsiSquared(R, Z)
-        self.Bp_R = lambda R, Z: self._dct.ddZ(R, Z) / R
-        self.Bp_Z = lambda R, Z: -self._dct.ddR(R, Z) / R
-        self.d2psidR2 = self._dct.d2dR2
-        self.d2psidZ2 = self._dct.d2dZ2
-        self.d2psidRdZ = self._dct.d2dRdZ
+        self._f_R = lambda R, Z: self._dct.ddR(R, Z) / modGradpsiSquared(R, Z)
+        self._f_Z = lambda R, Z: self._dct.ddZ(R, Z) / modGradpsiSquared(R, Z)
+        self._Bp_R = lambda R, Z: self._dct.ddZ(R, Z) / R
+        self._Bp_Z = lambda R, Z: -self._dct.ddR(R, Z) / R
+        self._d2psidR2 = self._dct.d2dR2
+        self._d2psidZ2 = self._dct.d2dZ2
+        self._d2psidRdZ = self._dct.d2dRdZ
+
+    # Define self.psi(), etc. so we can override in TokamakEquilibrium
+    def psi(self, *args):
+        return self._psi(*args)
+
+    def f_R(self, *args):
+        return self._f_R(*args)
+
+    def f_Z(self, *args):
+        return self._f_Z(*args)
+
+    def Bp_R(self, *args):
+        return self._Bp_R(*args)
+
+    def Bp_Z(self, *args):
+        return self._Bp_Z(*args)
+
+    def d2psidR2(self, *args):
+        return self._d2psidR2(*args)
+
+    def d2psidZ2(self, *args):
+        return self._d2psidZ2(*args)
+
+    def d2psidRdZ(self, *args):
+        return self._d2psidRdZ(*args)
 
     def findMinimum_1d(self, pos1, pos2, atol=1.0e-14):
         def coords(s):


### PR DESCRIPTION
Add a new option `psi_interpolation_method` to allow choosing Discrete Cosine Transformation interpolation in `TokamakEquilibrium`. Also one small addition to enable DCT to work.

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [x] Updated `doc/whats-new.md` with a summary of the changes
