### PR TITLE
Option to start grid from upper-outer divertor instead of lower-inner

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -21,6 +21,8 @@ What's new
 
 ### New features
 
+- Option to start grid at upper-outer divertor instead of lower-inner (#80)\
+  By [John Omotani](https://github.com/johnomotani)
 - Smoothing copied from IDL hypnotoad for components of curvature vector (#79)\
   By [John Omotani](https://github.com/johnomotani)
 - Check for unrecognised options in input files and raise an error if any are found

--- a/hypnotoad/cases/tokamak.py
+++ b/hypnotoad/cases/tokamak.py
@@ -218,6 +218,17 @@ class TokamakEquilibrium(Equilibrium):
             ),
             value_type=[float, int, NoneType],
         ),
+        start_at_upper_outer=WithMeta(
+            False,
+            doc=(
+                "Start gridding double-null at upper-outer divertor instead of "
+                "lower-inner. Warning: this option was added to enable backward "
+                "compatibility with restart files from simulations in "
+                "upper-disconnected-double-null configuration using grid files from "
+                "the IDL hypnotoad; it is not well tested and not recommended to use."
+            ),
+            value_type=bool,
+        ),
         # Tolerance for positioning points that should be at X-point, but need to be
         # slightly displaced from the null so code can follow Grad(psi).
         # Number between 0. and 1.
@@ -1390,18 +1401,31 @@ class TokamakEquilibrium(Equilibrium):
         # BoutMesh generator can use jyseps indices to introduce branch cuts
 
         if "inner_lower_divertor" in region_objects:
-            ordering = [
-                "inner_lower_divertor",
-                # For single null; in double null this will be ignored
-                "core",
-                # For double null; in single null these will be ignored
-                "inner_core",
-                "inner_upper_divertor",
-                "outer_upper_divertor",
-                "outer_core",
-                #
-                "outer_lower_divertor",
-            ]
+            if not self.user_options.start_at_upper_outer:
+                ordering = [
+                    "inner_lower_divertor",
+                    # For single null; in double null this will be ignored
+                    "core",
+                    # For double null; in single null these will be ignored
+                    "inner_core",
+                    "inner_upper_divertor",
+                    "outer_upper_divertor",
+                    "outer_core",
+                    #
+                    "outer_lower_divertor",
+                ]
+            else:
+                # Special case intended for backward compatibility with simulations
+                # using upper-disconnected-double-null IDL-hypnotoad grid files
+                ordering = [
+                    "outer_upper_divertor",
+                    "outer_core",
+                    "outer_lower_divertor",
+                    "inner_lower_divertor",
+                    "core",
+                    "inner_core",
+                    "inner_upper_divertor",
+                ]
         else:
             # Upper single null special case
             ordering = ["outer_upper_divertor", "core", "inner_upper_divertor"]


### PR DESCRIPTION
Intended for backward compatibility with IDL-hypnotoad grid files for upper-disconnected-double-null cases.

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [x] Updated `doc/whats-new.md` with a summary of the changes
