### PR TITLE
Check fine contour when created

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -2,8 +2,17 @@ What's new
 ==========
 
 
-0.3.0 (25th January 2021)
+0.3.1 (unreleased)
 ------------------
+
+### Bug fixes
+
+- Ensure FineContours always extend to the end of their parent PsiContour (#86, fixes
+  #84)\
+  By [Ben Dudson](https://github.com/bendudson)
+
+0.3.0 (25th January 2021)
+-------------------------
 
 ### Breaking changes
 

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -963,6 +963,8 @@ class PsiContour:
     def fine_contour(self):
         if self._fine_contour is None:
             self._fine_contour = FineContour(self, dict(self.user_options))
+            # Ensure that the fine contour is long enough
+            self.checkFineContourExtend()
         return self._fine_contour
 
     @property

--- a/hypnotoad/test_suite/test_equilibrium.py
+++ b/hypnotoad/test_suite/test_equilibrium.py
@@ -598,6 +598,39 @@ class TestContour:
                 testcontour.Z0 + r * numpy.sin(theta), abs=1.0e-4
             )
 
+    def test_finecontour_extent_lower(self, testcontour):
+        contour = testcontour.c
+
+        contour_initial = contour[0]
+        del contour.points[0]
+        contour.endInd = contour.endInd - 1
+
+        # This will create contour._fine_contour and check that contour.distance
+        # is monotonic at this point
+        contour.distance
+
+        contour.prepend(contour_initial)
+
+        # Check that after modifying contour, contour._fine_contour still extends far
+        # enough to give a monotonic contour.distance
+        contour.distance
+
+    def test_finecontour_extent_upper(self, testcontour):
+        contour = testcontour.c
+
+        contour_final = contour[-1]
+        del contour.points[-1]
+        contour.endInd = contour.endInd - 1
+
+        # This will create contour._fine_contour and check that contour.distance
+        # is monotonic at this point
+        contour.distance
+
+        contour.append(contour_final)
+        # Check that after modifying contour, contour._fine_contour still extends far
+        # enough to give a monotonic contour.distance
+        contour.distance
+
 
 class ThisEquilibrium(Equilibrium):
     def __init__(self, settings=None):


### PR DESCRIPTION
Need to ensure that psi contour's fine contour extends far enough.
This is done when the fine contour is first created.

- [ ] Probably closes #84
