### PR TITLE
Make FineContour.getDistance more robust

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -5,6 +5,12 @@ What's new
 0.3.1 (unreleased)
 ------------------
 
+### New features
+
+- More robust calculation of distances in FineCountour.getDistance(), using
+  closest approach to line segments. Can be important for grids with sharp angles (#87)\
+  By [Ben Dudson](https://github.com/bendudson)
+
 ### Bug fixes
 
 - Ensure FineContours always extend to the end of their parent PsiContour (#86, fixes

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -372,7 +372,9 @@ def closest_approach(point, a, b):
 
     point, a, and b are all 2-element arrays
 
-    Algorithm from: https://monkeyproofsolutions.nl/wordpress/how-to-calculate-the-shortest-distance-between-a-point-and-a-line/
+    Algorithm from:
+    https://monkeyproofsolutions.nl/wordpress/
+       how-to-calculate-the-shortest-distance-between-a-point-and-a-line/
     """
     point = numpy.asarray(point)
     a = numpy.asarray(a)

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -366,6 +366,39 @@ def find_intersections(l1array, l2start, l2end):
         return None
 
 
+def closest_approach(point, a, b):
+    """Shortest distance between point and the line segment
+    between a and b.
+
+    point, a, and b are all 2-element arrays
+
+    Algorithm from: https://monkeyproofsolutions.nl/wordpress/how-to-calculate-the-shortest-distance-between-a-point-and-a-line/
+    """
+    point = numpy.asarray(point)
+    a = numpy.asarray(a)
+    b = numpy.asarray(b)
+
+    def dot(u, v):
+        """dot product of u and v, 2-element arrays"""
+        return numpy.sum(u * v)
+
+    def norm(v):
+        """Scalar norm of 2-element array v"""
+        return numpy.sqrt(dot(v, v))
+
+    m = b - a
+    t0 = dot(m, point - a) / dot(m, m)
+
+    if t0 < 0.0:
+        return norm(point - a)
+    if t0 > 1.0:
+        return norm(point - b)
+
+    # CPA intersects the segment
+    intersect = a + t0 * m
+    return norm(point - intersect)
+
+
 class FineContour:
     """
     Used to give a high-resolution representation of a contour.
@@ -822,7 +855,9 @@ class FineContour:
             i2 = i1 - 1
         elif i1 - 1 < 0:
             i2 = 1
-        elif distance_from_points[i1 + 1] < distance_from_points[i1 - 1]:
+        elif closest_approach(
+            p, self.positions[i1], self.positions[i1 + 1]
+        ) < closest_approach(p, self.positions[i1], self.positions[i1 - 1]):
             i2 = i1 + 1
         else:
             i2 = i1 - 1

--- a/hypnotoad/test_suite/test_equilibrium.py
+++ b/hypnotoad/test_suite/test_equilibrium.py
@@ -23,6 +23,7 @@ from copy import deepcopy
 from hypnotoad.core.equilibrium import (
     calc_distance,
     find_intersections,
+    closest_approach,
     Equilibrium,
     EquilibriumRegion,
     FineContour,
@@ -334,6 +335,31 @@ def test_find_intersectionZZNone4():
     l2start = Point2D(0.1, 2.0)
     intersect = find_intersections(l1, l2start, l2end)
     assert intersect is None
+
+
+def test_closest_approach_on_line():
+    cpa = closest_approach([0.5, 0.5], [0.0, 0.0], [1.0, 1.0])
+    assert numpy.isclose(cpa, 0.0)
+
+
+def test_closest_approach_out_left():
+    cpa = closest_approach([1.0, 0.0], [2.0, 0.0], [3.0, 0.0])
+    assert numpy.isclose(cpa, 1.0)
+
+
+def test_closest_approach_out_right():
+    cpa = closest_approach([3.5, 0.0], [2.0, 0.0], [3.0, 0.0])
+    assert numpy.isclose(cpa, 0.5)
+
+
+def test_closest_approach_above():
+    cpa = closest_approach([2.0, 0.3], [1.0, 0.0], [3.0, 0.0])
+    assert numpy.isclose(cpa, 0.3)
+
+
+def test_closest_approach_right():
+    cpa = closest_approach([1.5, 0.2], [1.0, 0.0], [1.0, 2.0])
+    assert numpy.isclose(cpa, 0.5)
 
 
 class TestContour:


### PR DESCRIPTION
Unusual cases failed where the contour has sharp corners, because the distance calculation picked the wrong point. 
Rather than using distances between points, use shortest distance to each line segment. This adds some overhead, but seems to be acceptably fast.

Includes tests of the new `closest_approach` function.

- [X] Tests added
