### PR TITLE
Add a parameter to control how far FineContours extend

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -13,6 +13,9 @@ What's new
 
 ### Bug fixes
 
+- Setting to adjust extension of FineContours past targets, may help to avoid crashes on
+  problematic equilibria (#96)\
+  By [John Omotani](https://github.com/johnomotani)
 - Diagnostic plots produced when some errors occur had invalid linestyles - use
   markers instead (#95, fixes #94)\
   By [John Omotani](https://github.com/johnomotani)

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -431,6 +431,19 @@ class FineContour:
             ),
             value_type=bool,
         ),
+        finecontour_extend_prefactor=WithMeta(
+            2.0,
+            doc=(
+                "Prefactor to increase estimate for number of points to extend "
+                "FineContour when y_boundary_guards>0. May be useful to decrease in "
+                "case of FineContour creation failures if the target end is very close "
+                "to a region with problematic psi (e.g. coils, centre column). If the "
+                "value is too small, may result in extrapolation using FineContour "
+                "points which is likely to be poorly constrained."
+            ),
+            value_type=float,
+            check_all=is_positive,
+        ),
         finecontour_maxits=WithMeta(
             200,
             doc=(
@@ -471,11 +484,19 @@ class FineContour:
 
         # Extend further than will be needed in the final contour, because extrapolation
         # past the end of the fine contour is very bad.
-        self.extend_lower_fine = (
-            2 * (self.parentContour.extend_lower * Nfine) // n_input
+        self.extend_lower_fine = int(
+            round(
+                self.user_options.finecontour_extend_prefactor
+                * (self.parentContour.extend_lower * Nfine)
+                / n_input
+            )
         )
-        self.extend_upper_fine = (
-            2 * (self.parentContour.extend_upper * Nfine) // n_input
+        self.extend_upper_fine = int(
+            round(
+                self.user_options.finecontour_extend_prefactor
+                * (self.parentContour.extend_upper * Nfine)
+                / n_input
+            )
         )
 
         self.indices_fine = numpy.linspace(

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -510,7 +510,12 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         # Create all the geometrical quantities
         try:
             self.mesh.geometry()
-        except (ValueError, TypeError, func_timeout.FunctionTimedOut) as e:
+        except (
+            ValueError,
+            TypeError,
+            func_timeout.FunctionTimedOut,
+            SolutionError,
+        ) as e:
             self._popup_error_message(e)
             return
 


### PR DESCRIPTION
On some grids where the targets are too close to a coil or the centre column, FineContour refinement may fail if the FineContour extends too far. This PR adds another settable parameter which can be adjusted for these cases.

- [x] Updated `doc/whats-new.md` with a summary of the changes
