### PR TITLE
Fix saving of options to grid files

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -7,6 +7,9 @@ What's new
 
 ### New features
 
+- Options are saved as a YAML string in "hypnotoad_inputs_yaml" to make them
+  easier to read in code later. (#98)\
+  By [John Omotani](https://github.com/johnomotani)
 - When exceptions are caught by the GUI, print the traceback as well as the
   exception message (#95)\
   By [John Omotani](https://github.com/johnomotani)

--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -13,6 +13,9 @@ What's new
 
 ### Bug fixes
 
+- Save all options to grid files. Previously only Equilibrium options were
+  saved. Now also Mesh and nonorthogonal options (#98)\
+  By [John Omotani](https://github.com/johnomotani)
 - Setting to adjust extension of FineContours past targets, may help to avoid crashes on
   problematic equilibria (#96)\
   By [John Omotani](https://github.com/johnomotani)

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -4403,23 +4403,3 @@ class Equilibrium:
             R = [p.R for p in region]
             Z = [p.Z for p in region]
             pyplot.scatter(R, Z, marker="x", label=region.name)
-
-    def _getOptionsAsString(self):
-        import yaml
-
-        result = ""
-        result += yaml.dump(self.user_options)
-
-        mesh_options_dict = {"Mesh": {}}
-        m = mesh_options_dict["Mesh"]
-        for key, val in self.user_options.items():
-            if val is not None:
-                m[key] = str(val)
-
-        result += yaml.dump(mesh_options_dict)
-
-        return result
-
-    def saveOptions(self, filename="hypnotoad_options.yaml"):
-        with open(filename, "x") as f:
-            f.write(self._getOptionsAsString())

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -25,6 +25,7 @@ from copy import deepcopy
 import numbers
 import re
 import warnings
+import yaml
 
 import numpy
 from optionsfactory import OptionsFactory, WithMeta
@@ -3451,6 +3452,10 @@ class BoutMesh(Mesh):
                 + self.user_options.as_table()
             )
             f.write("hypnotoad_inputs", inputs_string)
+            options_dict = dict(self.equilibrium.user_options)
+            options_dict.update(self.equilibrium.nonorthogonal_options)
+            options_dict.update(self.user_options)
+            f.write("hypnotoad_inputs_yaml", yaml.dump(options_dict))
 
             f.write_file_attribute("hypnotoad_version", self.version)
             if self.git_hash is not None:

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -3493,6 +3493,3 @@ class BoutMesh(Mesh):
                 "Some variable has not been defined yet: have you called "
                 "Mesh.geometry()?"
             )
-
-    def saveOptions(self, filename="hypnotoad_options.yaml"):
-        self.equilibrium.saveOptions(filename)

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -3438,7 +3438,19 @@ class BoutMesh(Mesh):
             # looking at a different variable, which would be inconvenient. It is not
             # likely that we need to load the hypnotoad inputs in BOUT++, so no reason
             # to save as an attribute.
-            f.write("hypnotoad_inputs", self.equilibrium._getOptionsAsString())
+            #
+            # Some options may be duplicated because of saving both equilibrium
+            # and mesh options, but no other way to make sure to get everything
+            # from subclasses (i.e. TokamakEquilibrium)
+            inputs_string = (
+                "Equilibrium options:\n"
+                + self.equilibrium.user_options.as_table()
+                + "\nNonorthogonal equilibrium options:\n"
+                + self.equilibrium.nonorthogonal_options.as_table()
+                + "\nMesh options:\n"
+                + self.user_options.as_table()
+            )
+            f.write("hypnotoad_inputs", inputs_string)
 
             f.write_file_attribute("hypnotoad_version", self.version)
             if self.git_hash is not None:


### PR DESCRIPTION
Previously only `Equilibrium.user_options` were saved to the grid files. Now also save `Equilibrium.nonorthogonal_options` and `Mesh.user_options`. The saved options are formatted as tables to make them easier to read.

Also add a new output `hypnotoad_inputs_yaml` containing all the imputs saved into a YAML-format string, to make them easier to re-load in future.

- [x] Updated `doc/whats-new.md` with a summary of the changes
