### PR TITLE
Improve accuracy of zShift calculation

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,7 +13,7 @@ jobs:
     if: always()
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
       fail-fast: false
 
     steps:
@@ -38,7 +38,7 @@ jobs:
     if: always()
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
       fail-fast: false
 
     steps:
@@ -66,7 +66,7 @@ jobs:
     if: always()
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2
@@ -90,7 +90,7 @@ jobs:
     if: always()
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -7,6 +7,9 @@ What's new
 
 ### New features
 
+- Accuracy of calculation of zShift improved by integrating on FineContours
+  rather than PsiContours (#101)\
+  By [John Omotani](https://github.com/johnomotani)
 - Parallelise most expensive loops (#99)\
   By [John Omotani](https://github.com/johnomotani)
 - Fix position of start and end points of contours when refining and add more tolerance

--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -7,11 +7,13 @@ What's new
 
 ### Breaking changes
 
+- Method for calculating zShift made more accurate. This will change the calculated
+  zShift for the same input file (#101)
 - Default value for 'curvature_type' changed from "curl(b/B) with x-y derivatives" to
   "curl(b/B)". New default should be more accurate and more consistent when changing
   grid sizes, but will produce slightly different output from the same input file. If
   the old behaviour is needed, set 'curvature_type = "curl(b/B) with x-y derivatives"'
-  explicitly.
+  explicitly (#100)
 
 ### New features
 

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -35,7 +35,8 @@ from optionsfactory.checks import (
     is_non_negative,
     is_positive,
 )
-from scipy.integrate import solve_ivp
+from scipy.integrate import cumulative_trapezoid, solve_ivp
+from scipy.interpolate import interp1d
 
 from boututils.boutarray import BoutArray
 from boututils.run_wrapper import shell_safe
@@ -1649,29 +1650,13 @@ class MeshRegion:
 
     def calcZShift(self):
         """
-        Calculate zShift by integrating dphidy in y.
+        Calculate zShift by integrating along FineContours.
         """
-        # Integrate using all available points - centre+ylow or xlow+corner.
-        # Integrate from lower boundary on open field lines.
-        # Integrate from lower side of MeshRegion with yGroupIndex=0 on closed field
-        # lines.
-        # Use trapezoid rule. If int_f = \int f dy
-        # int_f.centre[j] = int_f.centre[j-1]
-        #                   + 0.5*(f.centre[j-1] + f.ylow[j]) * (0.5*dy.centre[j-1])
-        #                   + 0.5*(f.ylow[j] + f.centre[j]) * (0.5*dy.centre[j])
-        #                 = i_centre[j-1] + i_ylow_upper[j]
-        #                   + i_ylow_lower[j] + i_centre[j]
-        # At the moment dy is a constant, but we allow for future changes with variable
-        # grid-spacing in y. The cell-centre points should be half way between the
-        # cell-face points, so the distance between centre[j-1] and ylow[j] is
-        # 0.5*dy[j-1], and the distace between ylow[j] and centre[j] is 0.5*dy[j]
-        #
-        # Also
-        # int_f.ylow[j] = int_f.ylow[j-1]
-        #                 + 0.5*(f.ylow[j-1] + f.centre[j-1]) * (0.5*dy.centre[j-1])
-        #                 + 0.5*(f.centre[j-1] + f.ylow[j]) * (0.5*dy.centre[j-1])
-        #               = i_ylow_lower[j-1] + i_centre[j-1]
-        #                 + i_centre[j-1] + i_ylow_upper[j]
+        # Step in toroidal direction for a step of length ds in the poloidal
+        # plane along a FineContour is ds*Bt/Bp.
+        # The change in toroidal angle is therefore (ds Bt)/(R Bp).
+        # The toroidal angle along the FineContour can be calculated by
+        # integrating using scipy.integrate.cumulative_trapezoid
 
         # Cannot just test 'connections['lower'] is not None' because periodic regions
         # always have a lower connection - requires us to give a yGroupIndex to each
@@ -1681,71 +1666,77 @@ class MeshRegion:
 
         region = self
         region.zShift = MultiLocationArray(region.nx, region.ny)
+        region.zShift.centre[:, :] = 0.0
+        region.zShift.ylow[:, :] = 0.0
+        region.zShift.xlow[:, :] = 0.0
+        region.zShift.corners[:, :] = 0.0
         while True:
-            # calculate integral for field lines with centre and ylow points
-            i_centre = 0.25 * numpy.cumsum(
-                region.dphidy.centre * region.dy.centre, axis=1
-            )
-            i_ylow_lower = 0.25 * numpy.cumsum(
-                region.dphidy.ylow[:, :-1] * region.dy.centre, axis=1
-            )
-            i_ylow_upper = 0.25 * numpy.cumsum(
-                region.dphidy.ylow[:, 1:] * region.dy.centre, axis=1
-            )
+            print("calcZShift", region.name, end="\r", flush=True)
+            for i, contour in enumerate(region.contours):
+                fine_contour = contour.get_fine_contour(psi=self.equilibriumRegion.psi)
+                fine_distance = fine_contour.distance
 
-            region.zShift.centre[:, 0] = (
-                region.zShift.ylow[:, 0] + i_ylow_lower[:, 0] + i_centre[:, 0]
-            )
-            region.zShift.centre[:, 1:] = (
-                region.zShift.ylow[:, 0, numpy.newaxis]
-                + i_centre[:, :-1]
-                + i_ylow_upper[:, :-1]
-                + i_ylow_lower[:, 1:]
-                + i_centre[:, 1:]
-            )
+                def integrand_func(R, Z):
+                    Bt = (
+                        self.meshParent.equilibrium.fpol(
+                            self.meshParent.equilibrium.psi(R, Z)
+                        )
+                        / R
+                    )
+                    Bp = numpy.sqrt(
+                        self.meshParent.equilibrium.Bp_R(R, Z) ** 2
+                        + self.meshParent.equilibrium.Bp_Z(R, Z) ** 2
+                    )
+                    return Bt / (R * Bp)
 
-            region.zShift.ylow[:, 1:] = (
-                region.zShift.ylow[:, 0, numpy.newaxis]
-                + i_ylow_lower
-                + 2.0 * i_centre
-                + i_ylow_upper
-            )
+                integrand = integrand_func(
+                    fine_contour.positions[:, 0],
+                    fine_contour.positions[:, 1],
+                )
 
-            # repeat for field lines with xlow and corner points
-            i_xlow = 0.25 * numpy.cumsum(region.dphidy.xlow * region.dy.xlow, axis=1)
-            i_corners_lower = 0.25 * numpy.cumsum(
-                region.dphidy.corners[:, :-1] * region.dy.xlow, axis=1
-            )
-            i_corners_upper = 0.25 * numpy.cumsum(
-                region.dphidy.corners[:, 1:] * region.dy.xlow, axis=1
-            )
+                zShift_fine = cumulative_trapezoid(
+                    integrand, x=fine_distance, initial=0.0
+                )
 
-            region.zShift.xlow[:, 0] = (
-                region.zShift.corners[:, 0] + i_corners_lower[:, 0] + i_xlow[:, 0]
-            )
-            region.zShift.xlow[:, 1:] = (
-                region.zShift.corners[:, 0, numpy.newaxis]
-                + i_xlow[:, :-1]
-                + i_corners_upper[:, :-1]
-                + i_corners_lower[:, 1:]
-                + i_xlow[:, 1:]
-            )
+                # Make sure zShift_fine starts at the 'startInd' of the
+                # contour/fine_contour
+                zShift_fine[:] -= zShift_fine[fine_contour.startInd]
 
-            region.zShift.corners[:, 1:] = (
-                region.zShift.corners[:, 0, numpy.newaxis]
-                + i_corners_lower
-                + 2.0 * i_xlow
-                + i_corners_upper
-            )
+                zShift_interpolator = interp1d(
+                    fine_distance, zShift_fine, kind="linear", assume_sorted=True
+                )
+                zShift_contour = zShift_interpolator(
+                    contour.get_distance(psi=self.equilibriumRegion.psi)
+                )
+
+                if i % 2 == 0:
+                    # xlow and corners
+                    xind = i // 2
+                    region.zShift.corners[xind, :] += zShift_contour[::2]
+                    region.zShift.xlow[xind, :] += zShift_contour[1::2]
+                else:
+                    # centre and ylow
+                    xind = i // 2
+                    region.zShift.ylow[xind, :] += zShift_contour[::2]
+                    region.zShift.centre[xind, :] += zShift_contour[1::2]
 
             next_region = region.getNeighbour("upper")
             if (next_region is None) or (next_region is self):
                 # Note: If periodic, next_region is self (back to start)
                 break
             else:
+                # Initialise with values at the lower y-boundary of next_region
                 next_region.zShift = MultiLocationArray(next_region.nx, next_region.ny)
-                next_region.zShift.ylow[:, 0] = region.zShift.ylow[:, -1]
-                next_region.zShift.corners[:, 0] = region.zShift.corners[:, -1]
+                next_region.zShift.centre[:, :] = region.zShift.ylow[
+                    :, -1, numpy.newaxis
+                ]
+                next_region.zShift.ylow[:, :] = region.zShift.ylow[:, -1, numpy.newaxis]
+                next_region.zShift.xlow[:, :] = region.zShift.corners[
+                    :, -1, numpy.newaxis
+                ]
+                next_region.zShift.corners[:, :] = region.zShift.corners[
+                    :, -1, numpy.newaxis
+                ]
                 region = next_region
 
         # Calculate ShiftAngle for closed field line regions

--- a/integrated_tests/connected_doublenull_nonorthogonal/expected_nonorthogonal.grd.nc
+++ b/integrated_tests/connected_doublenull_nonorthogonal/expected_nonorthogonal.grd.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ffa25ae3838a947ce5d6f27678e98f969ca1b9a15e656969df478b2e7f5e4798
+oid sha256:fd226e806de88b61140e72ef96a610c1cd16e788457332eef2fa5b80f9cdbae6
 size 415374

--- a/integrated_tests/connected_doublenull_nonorthogonal/expected_nonorthogonal.grd.nc
+++ b/integrated_tests/connected_doublenull_nonorthogonal/expected_nonorthogonal.grd.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:513b815cf7cf8e716bea22e2b8ab1d2fc385a92b9c129ba883278b73c79d4ce7
-size 362036
+oid sha256:68932f5d4d1b748724ee42faa7607417bb4c299d777eacc0786ee6bafebf2892
+size 362196

--- a/integrated_tests/connected_doublenull_orthogonal/expected_orthogonal.grd.nc
+++ b/integrated_tests/connected_doublenull_orthogonal/expected_orthogonal.grd.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cfeac0cc4115073e544dd45e07d74da196fed08776089a235eb9f4ecea8717d2
+oid sha256:3b435b68801be7655601c3f3f353da62371f966ecdffa2543c6a8f6d0a151dae
 size 424522

--- a/integrated_tests/connected_doublenull_orthogonal/expected_orthogonal.grd.nc
+++ b/integrated_tests/connected_doublenull_orthogonal/expected_orthogonal.grd.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:382d6683d73836101230fcbb7ff11173c08a08723dd6d66c4c6bf5d49b676c20
-size 369904
+oid sha256:bda56207b63962eeaf3521a2b248faf1b54560402be253a1bb605c0b5feef6ce
+size 370064

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
         "optionsfactory~=1.0.1",
         "pyparsing~=2.4",
         "PyYAML~=5.1",
-        "scipy~=1.4",
+        "scipy~=1.6",
         "Qt.py~=1.2",
     ],
     extras_require={"gui-pyside2": ["pyside2~=5.13"], "gui-PyQt5": ["PyQt5~=5.12"]},


### PR DESCRIPTION
Calculate `zShift` by integrating along `FineContours`. Should be more accurate than previous method that integrated using `PsiContour` points.

I think the new calculation is correct - even for the fairly coarse grids in the integrated tests, the differences in zShift between the new method and the old one are less than 1.5 radians, while the value of zShift is up to 100 radians. Checking on a higher resolution grid, the only errors as large as 1 radian are in positions where the integral has passed close to an X-point, which is where you would expect the calculations to have been least accurate.

This PR updates the dependencies to require scipy>=1.6. scipy-1.6 does not support Python-3.6, so also remove testing on Python-3.6. The requirement is not actually important (the change is just the rename of `scipy.integrate.cumtrapz` to `scipy.integrate.cumulative_trapezoid`, hypnotoad does not require any new functionality), but I don't see a strong reason to support older versions of scipy or Python. If anyone has objections, it's easy to restore backward compatibility to the previously supported versions.

- [x] Closes #35
- [x] Updated `doc/whats-new.md` with a summary of the changes
