### PR TITLE
Check if equilibrium can be gridded as connected double-null

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -2,6 +2,16 @@ What's new
 ==========
 
 
+0.4.1 (26th May 2021)
+---------------------
+
+### Bug fixes
+
+- Check if an equilibrium can be gridded as a connected double-null before gridding.
+  Prevents creation of invalid grids where second X-point is outside the first
+  flux-surface in the SOL (#104)\
+  By [John Omotani](https://github.com/johnomotani)
+
 0.4.0 (26th May 2021)
 ---------------------
 

--- a/hypnotoad/test_suite/test_tokamak.py
+++ b/hypnotoad/test_suite/test_tokamak.py
@@ -187,8 +187,8 @@ def test_bounding():
         np.linspace(Rmin, Rmax, nx),
         np.linspace(Zmin, Zmax, ny),
         np.zeros((nx, ny)),  # psi2d
-        [],
-        [],  # psi1d, fpol
+        np.linspace(0.0, 1.0, nx),  # psi1d
+        np.linspace(0.0, 1.0, nx),  # fpol1d
         make_regions=False,
     )
 
@@ -216,7 +216,12 @@ def test_xpoint():
         )
 
     eq = tokamak.TokamakEquilibrium(
-        r1d, z1d, psi_func(r2d, z2d), [], [], make_regions=False  # psi1d, fpol
+        r1d,
+        z1d,
+        psi_func(r2d, z2d),
+        np.linspace(0.0, 1.0, nx),  # psi1d
+        np.linspace(0.0, 1.0, nx),  # fpol1d
+        make_regions=False,
     )
 
     assert len(eq.x_points) == 1
@@ -245,8 +250,8 @@ def test_wall_anticlockwise():
         np.linspace(Rmin, Rmax, nx),
         np.linspace(Zmin, Zmax, ny),
         np.zeros((nx, ny)),  # psi2d
-        [],
-        [],  # psi1d, fpol
+        np.linspace(0.0, 1.0, nx),  # psi1d
+        np.linspace(0.0, 1.0, nx),  # fpol1d
         wall=wall,
         make_regions=False,
     )
@@ -275,8 +280,8 @@ def test_wall_clockwise():
         np.linspace(Rmin, Rmax, nx),
         np.linspace(Zmin, Zmax, ny),
         np.zeros((nx, ny)),  # psi2d
-        [],
-        [],  # psi1d, fpol
+        np.linspace(0.0, 1.0, nx),  # psi1d
+        np.linspace(0.0, 1.0, nx),  # fpol1d
         wall=wall,
         make_regions=False,
     )
@@ -312,7 +317,12 @@ def make_lower_single_null():
         )
 
     return tokamak.TokamakEquilibrium(
-        r1d, z1d, psi_func(r2d, z2d), [], [], make_regions=False  # psi1d, fpol
+        r1d,
+        z1d,
+        psi_func(r2d, z2d),
+        np.linspace(0.0, 1.0, nx),  # psi1d
+        np.linspace(0.0, 1.0, nx),  # fpol1d
+        make_regions=False,
     )
 
 
@@ -335,7 +345,12 @@ def make_upper_single_null():
         )
 
     return tokamak.TokamakEquilibrium(
-        r1d, z1d, psi_func(r2d, z2d), [], [], make_regions=False  # psi1d, fpol
+        r1d,
+        z1d,
+        psi_func(r2d, z2d),
+        np.linspace(0.0, 1.0, nx),  # psi1d
+        np.linspace(0.0, 1.0, nx),  # fpol1d
+        make_regions=False,
     )
 
 
@@ -359,7 +374,12 @@ def make_connected_double_null():
         )
 
     return tokamak.TokamakEquilibrium(
-        r1d, z1d, psi_func(r2d, z2d), [], [], make_regions=False  # psi1d, fpol
+        r1d,
+        z1d,
+        psi_func(r2d, z2d),
+        psi_func(np.linspace(1.6, 2.0, nx), np.zeros(nx)),  # psi1d
+        np.linspace(0.0, 1.0, nx),  # fpol1d
+        make_regions=False,
     )
 
 
@@ -382,7 +402,13 @@ def make_lower_double_null():
         )
 
     return tokamak.TokamakEquilibrium(
-        r1d, z1d, psi_func(r2d, z2d), [], [], make_regions=False  # psi1d, fpol
+        r1d,
+        z1d,
+        psi_func(r2d, z2d),
+        psi_func(np.linspace(1.6, 2.0, nx), np.zeros(nx)),  # psi1d
+        np.linspace(0.0, 1.0, nx),  # fpol1d
+        make_regions=False,
+        settings={"nx_inter_sep": 1},
     )
 
 
@@ -405,7 +431,13 @@ def make_upper_double_null():
         )
 
     return tokamak.TokamakEquilibrium(
-        r1d, z1d, psi_func(r2d, z2d), [], [], make_regions=False  # psi1d, fpol
+        r1d,
+        z1d,
+        psi_func(r2d, z2d),
+        psi_func(np.linspace(1.6, 2.0, nx), np.zeros(nx)),  # psi1d
+        np.linspace(0.0, 1.0, nx),  # fpol1d
+        make_regions=False,
+        settings={"nx_inter_sep": 1},
     )
 
 
@@ -431,8 +463,16 @@ def make_upper_double_null_largesep(settings={}):
             + np.exp(-((R - r0) ** 2 + (Z - 2 * z0) ** 2) / 0.3 ** 2)
         )
 
+    settings.update(nx_inter_sep=1)
+
     return tokamak.TokamakEquilibrium(
-        r1d, z1d, psi_func(r2d, z2d), [], [], make_regions=False, settings=settings
+        r1d,
+        z1d,
+        psi_func(r2d, z2d),
+        psi_func(np.linspace(1.6, 2.0, nx), np.zeros(nx)),  # psi1d
+        np.linspace(0.0, 1.0, nx),  # fpol1d
+        make_regions=False,
+        settings=settings,
     )
 
 


### PR DESCRIPTION
If the second separatrix is too far outside the first, it will be outside the first flux surface being gridded in the SOL, in which case the grid is not valid. Check for this and raise an exception.

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [x] Updated `doc/whats-new.md` with a summary of the changes
