### PR TITLE
Fix finding 'packages' in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/boutproject/hypnotoad",
-    packages=["hypnotoad"],
+    packages=setuptools.find_packages(include=("hypnotoad*",)),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",


### PR DESCRIPTION
A change to `setup.py` from #97 messed up the packaging so hypnotoad would not install correctly. This PR fixes that, making sure that the integrated tests (which have netcdf 'expected data' files) are not installed, but in a correct way.