### PR TITLE
Clean up examples

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -78,7 +78,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install sympy
+        pip install -e .
     - name: Examples
       run: |
         cd examples/tokamak
@@ -88,6 +89,9 @@ jobs:
         ./tokamak_example.py --no-plot ldn
         ./tokamak_example.py --no-plot udn
         ./tokamak_example.py --no-plot udn2
+        cd ../torpex-xpoint
+        hypnotoad_torpex --noplot torpex-coils.yaml
+        hypnotoad_torpex --noplot torpex-coils-nonorth.yaml
 
 
   flake8:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -60,6 +60,36 @@ jobs:
         ./test_suite.py
 
 
+  examples:
+
+    runs-on: ubuntu-latest
+    if: always()
+    strategy:
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        lfs: true
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Examples
+      run: |
+        cd examples/tokamak
+        ./tokamak_example.py --no-plot lsn
+        ./tokamak_example.py --no-plot usn
+        ./tokamak_example.py --no-plot cdn
+        ./tokamak_example.py --no-plot ldn
+        ./tokamak_example.py --no-plot udn
+        ./tokamak_example.py --no-plot udn2
+
+
   flake8:
 
     runs-on: ubuntu-latest

--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -2,6 +2,23 @@ What's new
 ==========
 
 
+0.4.3 (Unreleased)
+------------------
+
+### Bug fixes
+
+- Minor fixes updating TORPEX case (#106)\
+  By [John Omotani](https://github.com/johnomotani)
+- Fix crash in hypnotoad-gui if input file did not contain an 'orthogonal'
+  setting (#106)\
+  By [John Omotani](https://github.com/johnomotani)
+
+### New features
+
+- Clean up of examples. Input files from examples/tokamak can now be used with
+  hypnotoad-gui (#106)\
+  By [John Omotani](https://github.com/johnomotani)
+
 0.4.1 (26th May 2021)
 ---------------------
 

--- a/examples/tokamak/README.md
+++ b/examples/tokamak/README.md
@@ -1,19 +1,29 @@
-To generate a single null tokamak equilibrium:
+To generate a tokamak grid for a simple poloidal flux, psi, given by an
+analytic function:
 
-$ ./tokamak_example.py single-null.yaml
+    $ ./tokamak_example.py <type>
 
-A lower double null equilibrium:
+Where `<type>` is one of:
+* `lsn`   Lower Single Null
+* `usn`   Upper Single Null
+* `cdn`   Connected Double Null
+* `udn`   Upper Double Null
+* `ldn`   Lower Double Null
+* `udn2`  Upper Double Null, with a larger gap between separatrices.
 
-$ ./tokamak_example.py lower-double-null.yaml
+The input files `single-null.yaml`, `connected-double-null.yaml` and
+`disconnected-double-null.yaml` can be modified to change the grids for the
+corresponding cases.
 
-Those inputs can be modified to generate additional inputs.
-The analytic poloidal flux functions can be chosen with
-the geometry setting:
-
-"lsn"   Lower Single Null
-"usn"   Upper Single Null
-"cdn"   Connected Double Null
-"udn"   Upper Double Null
-"ldn"   Lower Double Null
-"udn2"  Upper Double Null, with a larger gap between separatrices.
-
+`tokamak_example.py` takes the additional arguments:
+* `--np`, `--number-of-processors` sets the number of processors to use
+    (default is to run in serial)
+* `--nx` number of points (in major radius direction) to use when discretising
+    psi on a Cartesian grid. Higher numbers give a more accurate psi. Does not
+    affect the number of points in the generated grid.
+* `--ny` number of points (in vertical direction) to use when discretising psi
+    on a Cartesian grid. Higher numbers give a more accurate psi. Does not
+    affect the number of points in the generated grid.
+* `--no-plot` Do not produce plots. Means the script produces no output - only
+    useful for checking if it can run without error in continuous integration
+    testing.

--- a/examples/tokamak/connected-double-null.yaml
+++ b/examples/tokamak/connected-double-null.yaml
@@ -1,12 +1,6 @@
-# Input for tokamak example in lower single null
+# Input for tokamak example in connected double null
 #
 # Note: Other available options will be printed when the regions are generated
-
-# Generate the poloidal flux input
-
-geometry: "ldn"
-nx: 65
-ny: 65
 
 # Ranges of normalised poloidal flux
 
@@ -34,6 +28,5 @@ psi_spacing_separatrix_multiplier: 0.5   # Smaller -> pack near separatrix
 
 # Poloidal grid spacing
 
-target_poloidal_spacing_length: 0.05   # Smaller -> pack near targets
+target_all_poloidal_spacing_length: 0.05   # Smaller -> pack near targets
 xpoint_poloidal_spacing_length: 0.05   # Smaller -> pack near X-points
-

--- a/examples/tokamak/disconnected-double-null.yaml
+++ b/examples/tokamak/disconnected-double-null.yaml
@@ -1,4 +1,4 @@
-# Input for tokamak example in lower single null
+# Input for tokamak example in disconnected double null geometries
 #
 # Note: Other available options will be printed when the regions are generated
 
@@ -10,13 +10,17 @@ psinorm_pf: 0.9
 
 # Number of points in poloidal regions
 
-ny_inner_divertor: 4
-ny_sol: 8
-ny_outer_divertor: 4
+ny_inner_lower_divertor: 4
+ny_inner_upper_divertor: 4
+ny_inner_sol: 4
+ny_outer_sol: 4
+ny_outer_lower_divertor: 4
+ny_outer_upper_divertor: 4
 
 # Number of points in radial segments
 
 nx_core: 5
+nx_inter_sep: 1
 nx_sol: 5
 
 # Radial grid spacing

--- a/examples/torpex-xpoint/README.md
+++ b/examples/torpex-xpoint/README.md
@@ -1,8 +1,8 @@
 To generate a grid file for a TORPEX X-point configuration, run
 
-    $ ../../torpex.py torpex-coils.yaml
+    $ hypnotoad_torpex torpex-coils.yaml
 
 or for a grid with the x-direction not restricted to be orthogonal to
 flux-surfaces
 
-    $ ../../torpex.py torpex-coils-nonorth.yaml
+    $ hypnotoad_torpex torpex-coils-nonorth.yaml

--- a/examples/torpex-xpoint/torpex-coils-nonorth.yaml
+++ b/examples/torpex-xpoint/torpex-coils-nonorth.yaml
@@ -20,9 +20,6 @@ Bt_axis: 77.e-3
 
 Mesh:
   orthogonal: False
-  # Should prefere 'curl(b/B' option, but implementation still needs checking
-  #curvature_type: 'curl(b/B)'
-  curvature_type: 'curl(b/B) with x-y derivatives'
   nx_core: 8
   nx_sol: 8
   ny_inner_lower_divertor: 8

--- a/examples/torpex-xpoint/torpex-coils.yaml
+++ b/examples/torpex-xpoint/torpex-coils.yaml
@@ -19,9 +19,6 @@ Coils:
 Bt_axis: 77.e-3
 
 Mesh:
-  # Should prefere 'curl(b/B' option, but implementation still needs checking
-  #curvature_type: 'curl(b/B)'
-  curvature_type: 'curl(b/B) with x-y derivatives'
   nx_core: 8
   nx_sol: 8
   ny_inner_lower_divertor: 8

--- a/hypnotoad/cases/torpex.py
+++ b/hypnotoad/cases/torpex.py
@@ -137,9 +137,6 @@ class TORPEXMagneticField(Equilibrium):
 
         print(self.user_options.as_table())
 
-        # Call Equilibrium constructor after adding stuff to options
-        super().__init__(meshOptions)
-
         if "Coils" in equilibOptions:
             self.coils = [Coil(**c) for c in equilibOptions["Coils"]]
 
@@ -294,6 +291,9 @@ class TORPEXMagneticField(Equilibrium):
             warnings.warn(
                 "Warning: failed to find X-point. Equilibrium generation will fail"
             )
+
+        # Call Equilibrium constructor after adding stuff to options
+        super().__init__(meshOptions)
 
     def TORPEX_wall(self, theta):
         """
@@ -522,7 +522,7 @@ class TORPEXMagneticField(Equilibrium):
                 points=[Point2D(R, Z) for R, Z in zip(legR, legZ)],
                 psival=self.psi_sep[0],
             )
-            self.regions[name] = leg.getRefined()
+            self.regions[name] = leg.getRefined(psi=self.psi)
             wall_vectors[name] = self.wallVector(boundary_position)
 
         # Make the SeparatrixContours go around clockwise
@@ -646,11 +646,14 @@ def createMesh(filename):
 
     equilibrium = TORPEXMagneticField(equilibOptions, meshOptions)
 
+    # Pick up any changes due to default options, etc.
+    meshOptions.update(equilibrium.user_options)
+
     print("X-point", equilibrium.x_points[0], "with psi=" + str(equilibrium.psi_sep[0]))
 
     equilibrium.makeRegions()
 
-    return BoutMesh(equilibrium, settings=equilibrium.user_options)
+    return BoutMesh(equilibrium, settings=meshOptions)
 
 
 def createEqdsk(equilib, *, nR, Rmin, Rmax, nZ, Zmin, Zmax, filename="torpex_test.g"):

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -4063,10 +4063,10 @@ class Equilibrium:
         except AttributeError:
             # wall interpolation functions not created yet
 
-            R = self.closed_wall_array[:, 0]
-            Z = self.closed_wall_array[:, 1]
+            R = self.closed_wallarray[:, 0]
+            Z = self.closed_wallarray[:, 1]
 
-            wallfraction = numpy.linspace(0.0, 1.0, len(self.wall))
+            wallfraction = numpy.linspace(0.0, 1.0, len(R))
 
             self.wallRInterp = interp1d(
                 wallfraction, R, kind="linear", assume_sorted=True

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -1090,7 +1090,7 @@ class PsiContour:
 
                 import matplotlib.pyplot as plt
 
-                self.plot(marker="o", color="k")
+                self.plot(marker="o", color="k", psi=psi)
 
                 fine_contour.plot(marker="x", color="r")
 

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -300,7 +300,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
             return
 
         # Skip options handled specially elsewhere
-        del filtered_options["orthogonal"]
+        filtered_options.pop("orthogonal", None)
         del filtered_defaults["orthogonal"]
 
         self.options_form.setSortingEnabled(False)
@@ -372,7 +372,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.options_file_line_edit.setText(filename)
         self.filename = filename
         self.read_options()
-        self.nonorthogonal_box.setChecked(not self.options["orthogonal"])
+        self.nonorthogonal_box.setChecked(not self.options.get("orthogonal", True))
 
     def read_options(self):
         """Read the options file"""

--- a/hypnotoad/scripts/hypnotoad_torpex.py
+++ b/hypnotoad/scripts/hypnotoad_torpex.py
@@ -43,6 +43,7 @@ def main():
     if not args.noplot:
         from matplotlib import pyplot
 
+    import gc
     from ..cases.torpex import createMesh
 
     filename = args.filename
@@ -69,6 +70,9 @@ def main():
         pyplot.show()
 
     mesh.writeGridfile(gridname)
+
+    del mesh
+    gc.collect()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Update for examples:
* input files in `examples/tokamak` can now be used with `hypnotoad-gui`. Geometry setting is now chosen with a command line option to the `tokamak_example.py` script instead of a setting in an input file.
* various small bug-fixes for TORPEX case where updates had broken things.
* fixes a bug where loading an input file with no 'orthogonal' setting would crash `hypnotoad-gui`.
* CI now checks that all the examples can run (although the output is not checked).

- [x] Updated `doc/whats-new.md` with a summary of the changes
