### PR TITLE
Set ixseps1>ixseps2 for upper disconnected double null case

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -11,6 +11,9 @@ What's new
   Prevents creation of invalid grids where second X-point is outside the first
   flux-surface in the SOL (#104)\
   By [John Omotani](https://github.com/johnomotani)
+- Correct setting of ixseps1 and ixseps2 for upper disconnected double null
+  case - should have ixseps1>ixseps2 but previously had ixseps1<ixseps2 (#109)\
+  By [John Omotani](https://github.com/johnomotani)
 
 0.4.0 (26th May 2021)
 ---------------------

--- a/hypnotoad/cases/tokamak.py
+++ b/hypnotoad/cases/tokamak.py
@@ -1039,6 +1039,8 @@ class TokamakEquilibrium(Equilibrium):
         if nx_inter_sep == 0:
             print("Generating a connected double null", flush=True)
 
+            self.double_null_type = "connected"
+
             # Only use psi of inner separatrix, not the outer one (if it is slightly
             # different)
             segments["upper_pf"]["psi_end"] = self.psi_sep[0]
@@ -1164,6 +1166,8 @@ class TokamakEquilibrium(Equilibrium):
             if self.x_points[0] == lower_x_point:
                 print("Lower double null", flush=True)
 
+                self.double_null_type = "lower"
+
                 inner_lower_segments = ["lower_pf", "near_sol", "inner_sol"]
                 outer_lower_segments = ["lower_pf", "near_sol", "outer_sol"]
 
@@ -1219,6 +1223,9 @@ class TokamakEquilibrium(Equilibrium):
 
             else:
                 print("Upper double null", flush=True)
+
+                self.double_null_type = "upper"
+
                 inner_lower_segments = ["lower_pf", "lower_pf2", "inner_sol"]
                 outer_lower_segments = ["lower_pf", "lower_pf2", "outer_sol"]
 

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -3568,8 +3568,17 @@ class BoutMesh(Mesh):
                 ixseps2 = self.nx
             elif len(self.x_startinds) == 4:
                 # Two separatrices
-                ixseps1 = self.x_startinds[1]
-                ixseps2 = self.x_startinds[2]
+                if self.equilibrium.double_null_type == "lower":
+                    ixseps1 = self.x_startinds[1]
+                    ixseps2 = self.x_startinds[2]
+                elif self.equilibrium.double_null_type == "upper":
+                    ixseps1 = self.x_startinds[2]
+                    ixseps2 = self.x_startinds[1]
+                else:
+                    raise ValueError(
+                        'Expected either double_null_type=="lower" or '
+                        'double_null_type="upper" when there are two separatrices.'
+                    )
             else:
                 raise ValueError("More than two separatrices not supported by BoutMesh")
 


### PR DESCRIPTION
Previously, hypnotoad always set `ixseps1 < ixseps2` when there are two separatrices. This is incorrect as `ixseps2 > `ixseps1` is the test BOUT++ uses to distinguish an upper-disconnected-double-null from a lower-disconnected-double-null.

- [x] Updated `doc/whats-new.md` with a summary of the changes
