### PR TITLE
Fix gui launching error

### DIFF
--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -3703,7 +3703,7 @@ class Equilibrium:
             doc=(
                 "Method to use for interpolating psi from the eqdsk file. Possible "
                 "values are: 'spline' for scipy.interpolate.RectBivariateSpline;"
-                "'dct' for a discrete cosine transform.",
+                "'dct' for a discrete cosine transform."
             ),
             value_type=str,
             allowed=["spline", "dct"],


### PR DESCRIPTION
Starting the gui failed with an error
```
$ hypnotoad-gui 
Traceback (most recent call last):
  File ".../bin/hypnotoad-gui", line 33, in <module>
    sys.exit(load_entry_point('hypnotoad', 'gui_scripts', 'hypnotoad-gui')())
  File ".../hypnotoad/hypnotoad/gui/__main__.py", line 22, in main
    window = HypnotoadGui()
  File ".../hypnotoad/hypnotoad/gui/gui.py", line 145, in __init__
    self.update_options_form()
  File ".../hypnotoad/hypnotoad/gui/gui.py", line 313, in update_options_form
    item0.setToolTip(value.doc)
TypeError: setToolTip(self, str): argument 1 has unexpected type 'tuple'
```

The error was caused by a misplaced comma, which turned what should have been a `str` into a `tuple`.