### PR TITLE
Save poloidal distances along psi-contours to grid files

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
     if: always()
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
       fail-fast: false
 
     steps:
@@ -42,7 +42,7 @@ jobs:
     if: always()
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
       fail-fast: false
 
     steps:
@@ -78,7 +78,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -104,7 +104,7 @@ jobs:
     if: always()
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: 3.9
 
     steps:
     - uses: actions/checkout@v2
@@ -128,7 +128,7 @@ jobs:
     if: always()
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: 3.9
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: 3.9
 
     steps:
     - uses: actions/checkout@v2
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: 3.9
 
     steps:
     - uses: actions/checkout@v2

--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -21,6 +21,8 @@ What's new
 
 ### New features
 
+- Save poloidal distances along psi contours to grid file (#116)\
+  By [John Omotani](https://github.com/johnomotani)
 - Enable DCT interpolation scheme in TokamakEquilibrum, can be selected with new option
   psi_interpolation_method (#113)\
   By [John Omotani](https://github.com/johnomotani)

--- a/integrated_tests/connected_doublenull_nonorthogonal/expected_nonorthogonal.grd.nc
+++ b/integrated_tests/connected_doublenull_nonorthogonal/expected_nonorthogonal.grd.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:12115fb65fbd8614a16a7a08b8d2970b56a8cb6156c95055d3b427c0edfe68c8
-size 419977
+oid sha256:b1969367565c41955666f94b49d31a111f8794fececbd37ceae47ed901372ac8
+size 411761

--- a/integrated_tests/connected_doublenull_orthogonal/expected_orthogonal.grd.nc
+++ b/integrated_tests/connected_doublenull_orthogonal/expected_orthogonal.grd.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0aa8bdc34360c2f4c24d032fcaf5a87f93ba89bafb48a28f19e91baeedb2d033
-size 431439
+oid sha256:380d8c2984c6312b504dd8d4a1d3b03c723b46f404f955b8282ed95bbf4637c1
+size 420837


### PR DESCRIPTION
Save poloidal distances as these can be useful for post-processing.

Also save the total poloidal distance in the core region. Since guard cells at the branch cut are not saved to the grid file, the total distance around the core region(s) would not be saved if we did not create a special variable for it.

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [x] Updated `doc/whats-new.md` with a summary of the changes
