### PR TITLE
Fix circular geometry with non-constant q

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -4,6 +4,11 @@ What's new
 0.4.4 (unreleased)
 ------------------
 
+### Bug fixes
+
+- Fix for circular geometries with non-constant q (#120)\
+  By [John Omotani](https://github.com/johnomotani)
+
 ### New features
 
 - Command to recreate input file and gfile from a grid file (#119)\


### PR DESCRIPTION
Previously, q(r) was given as a polynomial with linear terms. The analytical expressions given for non-constant q (i.e. more than one term in the expansion) gave sensible answers for very restricted values of the coefficients if at all. To be consistent at the magnetic axis, the series for q(r) should only have even powers of r. The update provides a correct expression for the new 2-coefficient case `q(r)=a0+a1*r**2`. It does not seem to be possible to get a closed form expression for the 3-coefficient case `q(r)=a0+a1*r**2+a2*r**4` from Mathematica without it
being written as a complex expression, even though the value is real, so this case is omitted.

- [x] Updated `doc/whats-new.md` with a summary of the changes
