### PR TITLE
Fix flake8 config file for fussier parser

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,11 +1,10 @@
 [flake8]
 max-line-length = 89
-ignore = (
+ignore =
     E741, # 'ambiguous variable names' forbids using 'I', 'O' or 'l'
     W503, # 'line break before binary operator', but this is allowed and useful inside brackets
     E203, # 'whitespace before ':'', but black formats some slice expressions with space before ':'
     E231, # missing whitespace after ',', but black formats some expressions without space after ','
-)
 exclude =
     hypnotoad/gui/hypnotoad_mainWindow.py,
     hypnotoad/gui/hypnotoad_preferences.py,


### PR DESCRIPTION
flake8 5.x doesn't like the brackets