### PR TITLE
Fix psi_axis check when reverse_current=True

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -1,6 +1,14 @@
 What's new
 ==========
 
+0.4.5 (unreleased)
+------------------
+
+### Bug fixes
+
+- Fix `psi_axis` check when `reverse_current=True` (#131)\
+  By [John Omotani](https://github.com/johnomotani)
+
 0.4.4
 -----
 

--- a/hypnotoad/cases/tokamak.py
+++ b/hypnotoad/cases/tokamak.py
@@ -468,9 +468,10 @@ class TokamakEquilibrium(Equilibrium):
             self.psi_bdry = xpoints[0][2]  # Psi on primary X-point
             self.x_point = Point2D(xpoints[0][0], xpoints[0][1])
             self.psi_bdry_gfile = psi_bdry_gfile
+            psi_reverse_sign = -1.0 if self.user_options.reverse_current else 1.0
             if (
                 psi_bdry_gfile is not None
-                and abs(self.psi_bdry - psi_bdry_gfile) > 1.0e-3
+                and abs(self.psi_bdry - psi_reverse_sign * psi_bdry_gfile) > 1.0e-3
             ):
                 raise ValueError(
                     f"psi_bdry from the gfile ({psi_bdry_gfile}) is different from psi "

--- a/hypnotoad/cases/tokamak.py
+++ b/hypnotoad/cases/tokamak.py
@@ -452,9 +452,10 @@ class TokamakEquilibrium(Equilibrium):
             self.psi_axis = opoints[0][2]  # Psi on magnetic axis
             self.o_point = Point2D(opoints[0][0], opoints[0][1])
             self.psi_axis_gfile = psi_axis_gfile
+            psi_reverse_sign = -1.0 if self.user_options.reverse_current else 1.0
             if (
                 psi_axis_gfile is not None
-                and abs(self.psi_axis - psi_axis_gfile) > 1.0e-3
+                and abs(self.psi_axis - psi_reverse_sign * psi_axis_gfile) > 1.0e-3
             ):
                 raise ValueError(
                     f"psi_axis from the gfile ({psi_axis_gfile}) is different from psi "


### PR DESCRIPTION
When `reverse_current=True` is set, the `psi` used by the code is the negative of that in the geqdsk file. This needs to be accounted for in the check.

- [x] Updated `doc/whats-new.md` with a summary of the changes
