### PR TITLE
Less ambiguous description for ny_inner_sol/ny_outer_sol options

### DIFF
--- a/hypnotoad/cases/tokamak.py
+++ b/hypnotoad/cases/tokamak.py
@@ -167,13 +167,15 @@ class TokamakEquilibrium(Equilibrium):
         ),
         ny_inner_sol=WithMeta(
             lambda options: options.ny_sol // 2,
-            doc="Number of poloidal points in the inner SOL upstream of the X-point(s)",
+            doc="Number of poloidal points in the inboard SOL upstream of the "
+            "X-point(s)",
             value_type=int,
             check_all=is_positive,
         ),
         ny_outer_sol=WithMeta(
             lambda options: options.ny_sol - options.ny_inner_sol,
-            doc="Number of poloidal points in the outer SOL upstream of the X-point(s)",
+            doc="Number of poloidal points in the outboard SOL upstream of the "
+            "X-point(s)",
             value_type=int,
             check_all=is_positive,
         ),


### PR DESCRIPTION
Small improvement(s) to the help-strings:
* Less ambiguous description for ny_inner_sol/ny_outer_sol options: 'inboard' and 'outboard' are clearer than 'inner' and 'outer' as they cannot mean inner/outer in minor radius, they are only ever used to refer to location in major radius.

If anyone has other suggestions, please feel free to add/discuss here! I'll leave this PR open for a couple of weeks to give people a chance to think/complain.