### PR TITLE
WIP:Expose cocos setting in read_geqdsk

### DIFF
--- a/hypnotoad/cases/tokamak.py
+++ b/hypnotoad/cases/tokamak.py
@@ -1653,11 +1653,15 @@ class TokamakEquilibrium(Equilibrium):
 
 
 def read_geqdsk(
-    filehandle, settings=None, nonorthogonal_settings=None, make_regions=True
+    filehandle, settings=None, nonorthogonal_settings=None, make_regions=True, cocos = 1
 ):
     """
     Read geqdsk formatted data from a file object, returning
     a TokamakEquilibrium object
+
+    cocos   - COordinate COnventions. Not fully handled yet,
+              only whether psi is divided by 2pi or not.
+              if < 10 then psi is divided by 2pi, otherwise not.
 
     Inputs
     ------
@@ -1676,7 +1680,7 @@ def read_geqdsk(
 
     from ..geqdsk._geqdsk import read as geq_read
 
-    data = geq_read(filehandle)
+    data = geq_read(filehandle, cocos)
 
     # Range of psi normalises psi derivatives
     psi_bdry_gfile = data["sibdry"]


### PR DESCRIPTION
The cocos setting in _geqdsk:
https://github.com/boutproject/hypnotoad/blob/43b0e74a9e5eb05d958a270b7c6ddb4a3ad0991e/hypnotoad/geqdsk/_geqdsk.py#L170

Was not exposed in read_geqdsk:
https://github.com/boutproject/hypnotoad/blob/43b0e74a9e5eb05d958a270b7c6ddb4a3ad0991e/hypnotoad/cases/tokamak.py#L1677-L1679

- [x] Exposed the setting in read_geqdsk
- [ ] Some more testing to ensure there's nothing more to do 
