### PR TITLE
GUI options fixes

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -8,6 +8,17 @@ What's new
 
 - Fix `psi_axis` check when `reverse_current=True` (#131)\
   By [John Omotani](https://github.com/johnomotani)
+- Errors when setting options could crash GUI. Can now change string options in
+  GUI. Reset to old value if invalid value is passed for some option. Type name
+  is actually shown in error message pop-up when incorrect type is passed
+  (#134)\
+  By [John Omotani](https://github.com/johnomotani)
+
+### New features
+
+- If an `int` (or other `Number`) literal is passed to a float-type option, it
+  is converted implicitly instead of causing an error. (#134)\
+  By [John Omotani](https://github.com/johnomotani)
 
 0.4.4
 -----

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -343,7 +343,11 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
                 if key in self.options:
                     del self.options[key]
             else:
-                self.options[key] = ast.literal_eval(item.text())
+                try:
+                    self.options[key] = ast.literal_eval(item.text())
+                except (ValueError, SyntaxError):
+                    # Value might have been string with some illegal character in
+                    self.options[key] = item.text()
 
         self.update_options_form()
 

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -298,7 +298,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
                 )
         except (ValueError, TypeError) as e:
             self._popup_error_message(e)
-            return
+            return False
 
         # Skip options handled specially elsewhere
         filtered_options.pop("orthogonal", None)
@@ -325,6 +325,8 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         self.options_form.setSortingEnabled(True)
         self.options_form.cellChanged.connect(self.options_form_changed)
 
+        return True
+
     def options_form_changed(self, row, column):
         """Change the options form from the widget table"""
 
@@ -335,6 +337,9 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
             raise ValueError("Not allowed to change option names")
         else:
             key = self.options_form.item(row, 0).text()
+            has_old_value = key in self.options
+            if has_old_value:
+                old_value = self.options[key]
 
             if item.text() == "":
                 # Reset to default
@@ -349,7 +354,13 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
                     # Value might have been string with some illegal character in
                     self.options[key] = item.text()
 
-        self.update_options_form()
+        if not self.update_options_form():
+            # Some error occured, reset the original value
+            if has_old_value:
+                self.options[key] = old_value
+            else:
+                del self.options[key]
+            self.update_options_form()
 
     def search_options_form(self, text):
         """Search for specific options"""

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -342,9 +342,8 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
                 # don't know how to get that
                 if key in self.options:
                     del self.options[key]
-                return
-
-            self.options[key] = ast.literal_eval(item.text())
+            else:
+                self.options[key] = ast.literal_eval(item.text())
 
         self.update_options_form()
 

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -274,12 +274,13 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
             tokamak.TokamakEquilibrium.nonorthogonal_options_factory.defaults
         )
 
-        # evaluate filtered_defaults using the values in self.options, so that any
-        # expressions get evaluated
-        filtered_default_values = dict(
-            BoutMesh.user_options_factory.create(self.options)
-        )
         try:
+            # evaluate filtered_defaults using the values in self.options, so that any
+            # expressions get evaluated
+            filtered_default_values = dict(
+                BoutMesh.user_options_factory.create(self.options)
+            )
+
             filtered_default_values.update(
                 tokamak.TokamakEquilibrium.user_options_factory.create(self.options)
             )

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
         "matplotlib~=3.2",
         "netCDF4~=1.5",
         "numpy~=1.18",
-        "optionsfactory~=1.0.1",
+        "optionsfactory~=1.0.7",
         "pyparsing>=2.4",
         "PyYAML>=5.1",
         "scipy~=1.6",


### PR DESCRIPTION
<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->
* Errors when setting options could crash GUI
* Can now change string options in GUI without crashing
* Reset to old value if invalid value is passed for some option
* Type name is actually shown in error message pop-up when incorrect type is passed
* If an `int` (or other `Number`) literal is passed to a float-type option, it is converted implicitly instead of causing an error.

- [x] Updated `doc/whats-new.md` with a summary of the changes

Fixes #134.
