### PR TITLE
Better orthogonal separatrix spacing for nonorthogonal grids

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,10 +1,14 @@
 [flake8]
 max-line-length = 89
+#E741 - 'ambiguous variable names' forbids using 'I', 'O' or 'l'
+#W503 - 'line break before binary operator', but this is allowed and useful inside brackets
+#E203 - 'whitespace before ':'', but black formats some slice expressions with space before ':'
+#E231 - missing whitespace after ',', but black formats some expressions without space after ','
 ignore =
-    E741, # 'ambiguous variable names' forbids using 'I', 'O' or 'l'
-    W503, # 'line break before binary operator', but this is allowed and useful inside brackets
-    E203, # 'whitespace before ':'', but black formats some slice expressions with space before ':'
-    E231, # missing whitespace after ',', but black formats some expressions without space after ','
+    E741,
+    W503,
+    E203,
+    E231,
 exclude =
     hypnotoad/gui/hypnotoad_mainWindow.py,
     hypnotoad/gui/hypnotoad_preferences.py,

--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -1,8 +1,28 @@
 What's new
 ==========
 
-0.4.5 (unreleased)
+0.5.0 (unreleased)
 ------------------
+
+### Breaking changes
+
+- Change how initial spacing of points on separatrix for nonorthogonal grids is
+  calculated (this spacing is used to construct the underlying orthogonal
+  grid). Now use weights that are just
+  {`cos(0.5*pi*i/index_length)**2`,`sin(0.5*pi*i/index_length)**2`} rather than
+  trying to construct a function that will give the same spacings when called
+  with the 'orthogonal spacing' that came from the initial call passed in as
+  `sfunc_orthogonal`. This means that the underlying orthogonal grid does not
+  rely at all on `nonorthogonal_*` settings, so removes an issue where some
+  grids could only be constructed by generating first with one set of
+  `nonorthogonal_*` settings, then changing them and regridding. It also
+  removes the possibility of a "Weight too small. Suggest increasing poloidal
+  'range' settings" error, since the branch that produced that error no longer
+  exists. Does change the nonorthogonal grids that will be produced by
+  hypnotoad, although the integrated tests pass without updating the expected
+  results, so the changes should be small (less than 1e-9 for the integrated
+  test cases) (#138)\
+  By [John Omotani](https://github.com/johnomotani)
 
 ### Bug fixes
 


### PR DESCRIPTION
Change how initial spacing of points on separatrix for nonorthogonal grids is calculated (this spacing is used to construct the underlying orthogonal grid). Now use weights that are just {`cos(0.5*pi*i/index_length)**2`,`sin(0.5*pi*i/index_length)**2`} rather than trying to construct a function that will give the same spacings when called with the 'orthogonal spacing' that came from the initial call passed in as `sfunc_orthogonal`. This means that the underlying orthogonal grid does not rely at all on `nonorthogonal_*` settings, so removes an issue where some grids could only be constructed by generating first with one set of `nonorthogonal_*` settings, then changing them and regridding. It also removes the possibility of a "Weight too small. Suggest increasing poloidal 'range' settings" error, since the branch that produced that error no longer exists. Does change the nonorthogonal grids that will be produced by hypnotoad, although the integrated tests pass without updating the expected results, so the changes should be small (less than 1e-9 for the integrated test cases)

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [x] Tests still pass
- [x] Updated `doc/whats-new.md` with a summary of the changes
