### PR TITLE
Fix check of X-point psi vs. psinorm_sol

### DIFF
--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -39,6 +39,8 @@ What's new
   is actually shown in error message pop-up when incorrect type is passed
   (#134)\
   By [John Omotani](https://github.com/johnomotani)
+- Fix potential error in check of X-point `psi` vs. `psinorm_sol` (#143)\
+  By [John Omotani](https://github.com/johnomotani)
 
 ### New features
 

--- a/hypnotoad/cases/tokamak.py
+++ b/hypnotoad/cases/tokamak.py
@@ -723,7 +723,7 @@ class TokamakEquilibrium(Equilibrium):
             *(
                 (psi, xpoint)
                 for psi, xpoint in zip(self.psi_sep, self.x_points)
-                if self._psi_to_psinorm(psi) < self.user_options.psinorm_sol
+                if self._psi_to_psinorm(psi) < self._psi_to_psinorm(self.psi_sol)
             )
         )
 


### PR DESCRIPTION
Using self.user_options.psinorm_sol runs the risk of causing an error if the user set psi_sol in the input rather than psinorm_sol. Better to use self.psi_sol (and convert it to psinorm) as then all user inputs are taken into account.

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [x] Updated `doc/whats-new.md` with a summary of the changes
