### PR TITLE
Bump required Python version to 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setuptools.setup(
         "Qt.py~=1.2",
     ],
     extras_require={"gui-pyside2": ["pyside2~=5.13"], "gui-PyQt5": ["PyQt5~=5.12"]},
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     entry_points={
         "console_scripts": [
             "hypnotoad-circular = hypnotoad.scripts.hypnotoad_circular:main",


### PR DESCRIPTION
We no longer test 3.6 or 3.7 in the CI, so require Python-3.8. Python-3.6 is no longer supported, and Python-3.7 is end-of-life in June 2023 anyway.
