### PR TITLE
Add accidentally removed setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,7 @@
+import setuptools
+import versioneer
+
+setuptools.setup(
+    version=versioneer.get_version(),
+    cmdclass=versioneer.get_cmdclass(),
+)


### PR DESCRIPTION
The `setup.py` file is still needed by `versioneer`. I accidentally removed it during a bad rebase in #156.
