### PR TITLE
Catch RuntimeError when calling git diff

### DIFF
--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -2568,10 +2568,14 @@ class Mesh:
 
             hypnotoad_path = Path(hypnotoad_init_file).parent
 
-            retval, self.git_diff = shell_safe(
-                "cd " + str(hypnotoad_path) + "&& git diff", pipe=True
-            )
-            self.git_diff = self.git_diff.strip()
+            try:
+                retval, self.git_diff = shell_safe(
+                    "cd " + str(hypnotoad_path) + "&& git diff", pipe=True
+                )
+                self.git_diff = self.git_diff.strip()
+            except RuntimeError:
+                # Could not run git or get the diff
+                self.git_diff = "unknown"
 
         # Generate MeshRegion object for each section of the mesh
         self.regions = {}


### PR DESCRIPTION
If using a 'dirty' installation, running scripts from outside the repository can fail. This catches these errors.

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Udated manual
- [ ] Updated `doc/whats-new.md` with a summary of the changes
