### PR TITLE
Recommend editable installs for developers

### DIFF
--- a/doc/developer/developer.rst
+++ b/doc/developer/developer.rst
@@ -1,6 +1,18 @@
 Developing hypnotoad
 ====================
 
+When installing from the source code git repo for development, it is
+recommended to do an editable install ::
+
+    $ pip install --user -e .
+
+This method means the installed modules and command line tools link to the
+source code, so reflect changes you make, and avoids a possible error if the
+repo has uncommitted changes (is 'dirty') where ``git diff`` fails to run on
+the installed code. Note, if you use ``conda`` make sure all the dependencies
+(see ``pyproject.toml``) are already installed to avoid them being
+``pip``-installed and messing up dependency tracking.
+
 .. toctree::
 
    equilibrium

--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -4,6 +4,12 @@ Release history
 0.5.1 (18th January 2023)
 -------------------------
 
+### Bug fixes
+
+- Document that editable installs are recommended for developers in manual and
+  exception message (#167)\
+  By [John Omotani](https://github.com/johnomotani)
+
 ### New features
 
 - `PsiContour.plot()` and `FineContour.plot()` can be called with an `ax`

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -2573,9 +2573,18 @@ class Mesh:
 
             hypnotoad_path = Path(hypnotoad_init_file).parent
 
-            retval, self.git_diff = shell_safe(
-                "cd " + str(hypnotoad_path) + "&& git diff", pipe=True
-            )
+            try:
+                retval, self.git_diff = shell_safe(
+                    "cd " + str(hypnotoad_path) + "&& git diff", pipe=True
+                )
+            except RuntimeError as e:
+                raise RuntimeError(
+                    "`git diff` failed. It is recommended to do an editable install "
+                    "using `pip --user -e .` when developing. If you did a "
+                    "non-editable install, this error can occur if the repo was "
+                    "'dirty' when installed.\n\nThe error message was:\n" + str(e)
+                )
+
             self.git_diff = self.git_diff.strip()
 
         # Generate MeshRegion object for each section of the mesh


### PR DESCRIPTION
Developers should use editable pip-installs like `pip install --user -e .`. Not doing so could result in an error when running `git diff` if the repo was dirty (and would mean needing to re-install after every change to the source code). This PR documents this in the developer section of the manual, and the error message thrown if `git diff` does fail.

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [x] Closes #164
- [x] Udated manual
- [x] Updated `doc/whats-new.md` with a summary of the changes
