### PR TITLE
Save R,Z locations for all four corners of each cell

### DIFF
--- a/doc/grid-file.rst
+++ b/doc/grid-file.rst
@@ -154,6 +154,15 @@ Spatial positions
      - Major radius and height of the lower-left corner of each grid cell. Not
        needed by BOUT++, but may be useful for post-processing.
 
+   * - ``Rxy_lower_right_corners``, ``Zxy_lower_right_corners``,
+       ``Rxy_upper_right_corners``, ``Zxy_upper_right_corners``,
+       ``Rxy_upper_left_corners``, ``Zxy_upper_left_corners``
+
+     - Major radius and height of the other three corners of each grid cell.
+       Mostly redundant information with ``Rxy_corners`` and ``Zxy_corners``,
+       but may make handling branch cuts and upper/outer boundaries more
+       convenient. Not needed by BOUT++, but may be useful for post-processing.
+
 Grid spacings
 +++++++++++++
 

--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -12,6 +12,8 @@ Release history
 
 ### New features
 
+- Save R,Z locations for all four corners of each cell (#168)\
+  By [John Omotani](https://github.com/johnomotani)
 - `PsiContour.plot()` and `FineContour.plot()` can be called with an `ax`
   argument, and passing `psi` is optional (#163)\
   By [Ben Dudson](https://github.com/bendudson)

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -3311,7 +3311,7 @@ class BoutMesh(Mesh):
         # Call geometry() method of base class
         super().geometry()
 
-        def addFromRegions(name):
+        def addFromRegions(name, *, all_corners=False):
             # Collect a 2d field from the regions
             self.fields_to_output.append(name)
             f = MultiLocationArray(self.nx, self.ny)
@@ -3334,6 +3334,17 @@ class BoutMesh(Mesh):
                     f.corners[self.region_indices[region.myID]] = f_region.corners[
                         :-1, :-1
                     ]
+                if all_corners:
+                    if f_region._corners_array is not None:
+                        f.lower_right_corners[
+                            self.region_indices[region.myID]
+                        ] = f_region.corners[1:, :-1]
+                        f.upper_right_corners[
+                            self.region_indices[region.myID]
+                        ] = f_region.corners[1:, 1:]
+                        f.upper_left_corners[
+                            self.region_indices[region.myID]
+                        ] = f_region.corners[:-1, 1:]
 
             # Set 'bout_type' so it gets saved in the grid file
             f.attributes["bout_type"] = "Field2D"
@@ -3369,8 +3380,8 @@ class BoutMesh(Mesh):
             # Set 'bout_type' so it gets saved in the grid file
             f.attributes["bout_type"] = "ArrayX"
 
-        addFromRegions("Rxy")
-        addFromRegions("Zxy")
+        addFromRegions("Rxy", all_corners=True)
+        addFromRegions("Zxy", all_corners=True)
         addFromRegions("psixy")
         addFromRegions("dx")
         addFromRegions("dy")
@@ -3435,6 +3446,18 @@ class BoutMesh(Mesh):
         f.write(
             name + "_corners",
             BoutArray(array.corners[:-1, :-1], attributes=array.attributes),
+        )
+        f.write(
+            name + "_lower_right_corners",
+            BoutArray(array.lower_right_corners[:-1, :-1], attributes=array.attributes),
+        )
+        f.write(
+            name + "_upper_right_corners",
+            BoutArray(array.upper_right_corners[:-1, :-1], attributes=array.attributes),
+        )
+        f.write(
+            name + "_upper_left_corners",
+            BoutArray(array.upper_left_corners[:-1, :-1], attributes=array.attributes),
         )
 
     def writeArrayXDirection(self, name, array, f):

--- a/hypnotoad/core/multilocationarray.py
+++ b/hypnotoad/core/multilocationarray.py
@@ -6,12 +6,22 @@ class MultiLocationArray(numpy.lib.mixins.NDArrayOperatorsMixin):
     """
     Container for arrays representing points at different cell locations
     Not all have to be filled.
+
+    Note the ``lower_right_corners``, ``upper_right_corners``, and
+    ``upper_left_corners`` members are only intended to be used for the global arrays,
+    as within each region the ``corners`` member contains all the corners for every
+    cell. ``lower_right_corners``, ``upper_right_corners``, and ``upper_left_corners``
+    are therefore not set to zero in ``MultiLocationArray.zero()`` as they do not need
+    to be initialized.
     """
 
     _centre_array = None
     _xlow_array = None
     _ylow_array = None
     _corners_array = None
+    _lower_right_corners_array = None
+    _upper_right_corners_array = None
+    _upper_left_corners_array = None
 
     def __init__(self, nx, ny):
         self.nx = nx
@@ -66,6 +76,42 @@ class MultiLocationArray(numpy.lib.mixins.NDArrayOperatorsMixin):
         if self._corners_array is None:
             self._corners_array = numpy.zeros([self.nx + 1, self.ny + 1])
         self._corners_array[...] = value
+
+    @property
+    def lower_right_corners(self):
+        if self._lower_right_corners_array is None:
+            self._lower_right_corners_array = numpy.zeros([self.nx + 1, self.ny + 1])
+        return self._lower_right_corners_array
+
+    @lower_right_corners.setter
+    def lower_right_corners(self, value):
+        if self._lower_right_corners_array is None:
+            self._lower_right_corners_array = numpy.zeros([self.nx + 1, self.ny + 1])
+        self._lower_right_corners_array[...] = value
+
+    @property
+    def upper_right_corners(self):
+        if self._upper_right_corners_array is None:
+            self._upper_right_corners_array = numpy.zeros([self.nx + 1, self.ny + 1])
+        return self._upper_right_corners_array
+
+    @upper_right_corners.setter
+    def upper_right_corners(self, value):
+        if self._upper_right_corners_array is None:
+            self._upper_right_corners_array = numpy.zeros([self.nx + 1, self.ny + 1])
+        self._upper_right_corners_array[...] = value
+
+    @property
+    def upper_left_corners(self):
+        if self._upper_left_corners_array is None:
+            self._upper_left_corners_array = numpy.zeros([self.nx + 1, self.ny + 1])
+        return self._upper_left_corners_array
+
+    @upper_left_corners.setter
+    def upper_left_corners(self, value):
+        if self._upper_left_corners_array is None:
+            self._upper_left_corners_array = numpy.zeros([self.nx + 1, self.ny + 1])
+        self._upper_left_corners_array[...] = value
 
     def copy(self):
         new_multilocationarray = MultiLocationArray(self.nx, self.ny)
@@ -219,6 +265,13 @@ class MultiLocationArray(numpy.lib.mixins.NDArrayOperatorsMixin):
 
     def zero(self):
         # Initialise all locations, set them to zero and return the result
+        #
+        # Note the ``lower_right_corners``, ``upper_right_corners``, and
+        # ``upper_left_corners`` members are only intended to be used for the global
+        # arrays, as within each region the ``corners`` member contains all the corners
+        # for every cell. ``lower_right_corners``, ``upper_right_corners``, and
+        # ``upper_left_corners`` are therefore not set to zero here as they do not need
+        # to be initialized.
         self.centre = 0.0
         self.xlow = 0.0
         self.ylow = 0.0

--- a/integrated_tests/connected_doublenull_nonorthogonal/expected_nonorthogonal.grd.nc
+++ b/integrated_tests/connected_doublenull_nonorthogonal/expected_nonorthogonal.grd.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:330abcacf86376fd0f7f711286da44d8887d607a9d4d791a3ccf4c37e4187a41
-size 616299
+oid sha256:7dfb841cbbfbc89ab458c1e09e7108572521f40392bbb87164de419eb4353403
+size 638387

--- a/integrated_tests/connected_doublenull_orthogonal/expected_orthogonal.grd.nc
+++ b/integrated_tests/connected_doublenull_orthogonal/expected_orthogonal.grd.nc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e96a5c48ea259aaebf2a7993a434a478d4a8624bd432db37782e18b74c4aaf48
-size 631857
+oid sha256:1155390ac1606a4f89597e4a6699948b9d3aba819ebb4d597f897e71880e0d44
+size 656877


### PR DESCRIPTION
The corner positions can be useful for plotting, or coupling to other codes. Saving all four corners separately means no special handling is needed for branch cuts or boundaries, and there are no missing values (e.g. upper corners at an upper boundary).

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [x] Tests added
- [x] Udated manual
- [x] Updated `doc/whats-new.md` with a summary of the changes
