### PR TITLE
Add a View menu, improve grid plotting

### DIFF
--- a/doc/grid-file.rst
+++ b/doc/grid-file.rst
@@ -138,6 +138,27 @@ BoutMesh writes three poloidal coordinates to the grid file:
        full poloidal turn around a closed flux surface. Not calculated on open
        flux surfaces.
 
+Wall location
++++++++++++++
+
+If a wall is defined in the equilibrium then the coordinates of the
+closed wall is saved:
+
+.. list-table::
+   :widths: 30 70
+
+   * - ``closed_wall_R``
+
+     - Major radius locations [in meters] of points on the wall. This
+       array forms a closed loop so the last element is the same as
+       the first.
+
+   * - ``closed_wall_Z``
+
+     - Height locations [in meters] of points on the wall, the same
+       number of points as ``closed_wall_R``. This array forms a
+       closed loop so the last element is the same as the first.
+
 2D arrays
 ---------
 
@@ -210,6 +231,21 @@ Magnetic field quantities
    * - ``Bxy``
 
      - Total magnetic field.
+
+Boundary quantities
++++++++++++++++++++
+
+.. list-table::
+   :widths: 30 70
+
+   * - ``penalty_mask``
+
+     - A 2D mask indicating whether a cell is inside or outside the
+       wall. It's value is 1 for cells entirely outside the wall; 0
+       for cells entirely inside the wall. Cells that cross the wall
+       are given a penalty proportional to the fraction of the cell
+       poloidal length that is inside the wall.
+
 
 Integral quantities
 +++++++++++++++++++

--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -10,10 +10,11 @@ Release history
   a rough grid to help visual inspection when option
   `follow_perpendicular_recover` is set to True (#175)
 - A `View` menu enables the grid plot to be customised, with cell edges, corners,
-  grid lines and other components.
+  grid lines and other components (#176).
 - `penalty_mask` is calculated and written to the grid file, based on intersection
   of the grid with the wall. This enables immersed boundary conditions.
 - Wall coordinates are written to output grid as `closed_wall_R` and `closed_wall_Z`
+  (#176)
 
 0.5.2 (13th March 2023)
 -------------------------

--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -8,7 +8,7 @@ Release history
 
 - Radial grid line construction can recover from failure and generate
   a rough grid to help visual inspection when option
-  `follow_perpendicular_recover` is set to True
+  `follow_perpendicular_recover` is set to True (#175)
 - A `View` menu enables the grid plot to be customised, with cell edges, corners,
   grid lines and other components.
 - `penalty_mask` is calculated and written to the grid file, based on intersection

--- a/doc/whats-new.md
+++ b/doc/whats-new.md
@@ -1,6 +1,20 @@
 Release history
 ===============
 
+### Bug fixes
+
+
+### New features
+
+- Radial grid line construction can recover from failure and generate
+  a rough grid to help visual inspection when option
+  `follow_perpendicular_recover` is set to True
+- A `View` menu enables the grid plot to be customised, with cell edges, corners,
+  grid lines and other components.
+- `penalty_mask` is calculated and written to the grid file, based on intersection
+  of the grid with the wall. This enables immersed boundary conditions.
+- Wall coordinates are written to output grid as `closed_wall_R` and `closed_wall_Z`
+
 0.5.2 (13th March 2023)
 -------------------------
 

--- a/hypnotoad/cases/circular.py
+++ b/hypnotoad/cases/circular.py
@@ -293,9 +293,7 @@ class CircularEquilibrium(Equilibrium):
             def func(x):
                 return (
                     B0 / (np.sqrt(1.0 - x**2 / R0**2) * self.q(x))
-                    + B0
-                    * x**2
-                    / (R0**2 * (1.0 - x**2 / R0**2) ** 1.5 * self.q(x))
+                    + B0 * x**2 / (R0**2 * (1.0 - x**2 / R0**2) ** 1.5 * self.q(x))
                     - B0
                     * x
                     * self.dqdr(x)
@@ -326,10 +324,7 @@ class CircularEquilibrium(Equilibrium):
 
                 def func(x):
                     return (
-                        B0
-                        * R0**2
-                        / coef_array[0]
-                        * (1.0 - np.sqrt(1.0 - x**2 / R0**2))
+                        B0 * R0**2 / coef_array[0] * (1.0 - np.sqrt(1.0 - x**2 / R0**2))
                     )
 
                 self._psi_r = func
@@ -346,8 +341,7 @@ class CircularEquilibrium(Equilibrium):
                                 * (
                                     -1.0
                                     + np.sqrt(
-                                        (a1 * (-(x**2) + R0**2))
-                                        / (a0 + a1 * R0**2)
+                                        (a1 * (-(x**2) + R0**2)) / (a0 + a1 * R0**2)
                                     )
                                 )
                             )
@@ -356,8 +350,7 @@ class CircularEquilibrium(Equilibrium):
                                 * (
                                     1.0
                                     + np.sqrt(
-                                        (a1 * (-(x**2) + R0**2))
-                                        / (a0 + a1 * R0**2)
+                                        (a1 * (-(x**2) + R0**2)) / (a0 + a1 * R0**2)
                                     )
                                 )
                             )

--- a/hypnotoad/core/equilibrium.py
+++ b/hypnotoad/core/equilibrium.py
@@ -4792,10 +4792,7 @@ class Equilibrium:
                             * numpy.pi
                             * CosInt_m_j1
                             * numpy.sin(b * numpy.pi / n)
-                            + b**2
-                            * numpy.pi
-                            * numpy.cos(b * numpy.pi / n)
-                            * SinInt_b_n
+                            + b**2 * numpy.pi * numpy.cos(b * numpy.pi / n) * SinInt_b_n
                             - b
                             * j1(i)
                             * numpy.pi
@@ -4812,14 +4809,8 @@ class Equilibrium:
                             * numpy.pi
                             * numpy.cos(b * numpy.pi / n)
                             * SinInt_b_n
-                            + n**2
-                            * numpy.pi
-                            * numpy.cos(b * numpy.pi / n)
-                            * SinInt_b_n
-                            - b**2
-                            * numpy.pi
-                            * numpy.cos(b * numpy.pi / n)
-                            * SinInt_j1
+                            + n**2 * numpy.pi * numpy.cos(b * numpy.pi / n) * SinInt_b_n
+                            - b**2 * numpy.pi * numpy.cos(b * numpy.pi / n) * SinInt_j1
                             + b
                             * j1(i)
                             * numpy.pi
@@ -4836,10 +4827,7 @@ class Equilibrium:
                             * numpy.pi
                             * numpy.cos(b * numpy.pi / n)
                             * SinInt_j1
-                            - n**2
-                            * numpy.pi
-                            * numpy.cos(b * numpy.pi / n)
-                            * SinInt_j1
+                            - n**2 * numpy.pi * numpy.cos(b * numpy.pi / n) * SinInt_j1
                         )
                         + grad_upper / 2 * j2(i) * (b + n) / (b + j2(i))
                         - grad_upper

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -3727,6 +3727,10 @@ class BoutMesh(Mesh):
             if hasattr(self.equilibrium, "psi_bdry_gfile"):
                 f.write("psi_bdry_gfile", self.equilibrium.psi_bdry_gfile)
 
+            if hasattr(self.equilibrium, "closed_wallarray"):
+                f.write("closed_wall_R", self.equilibrium.closed_wallarray[:, 0])
+                f.write("closed_wall_Z", self.equilibrium.closed_wallarray[:, 1])
+
             # write the 2d fields
             for name in self.fields_to_output:
                 self.writeArray(name, self.__dict__[name], f)

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -460,11 +460,11 @@ class MeshRegion:
                 # along the contour where the grid would be orthogonal need to
                 # correct sfunc_orthogonal for the distance between the point at
                 # the lower wall and the original start-point
-                self.sfunc_orthogonal_list[
-                    i
-                ] = correct_sfunc_orthogonal_and_set_startInd(
-                    contour,
-                    self.sfunc_orthogonal_list[i],
+                self.sfunc_orthogonal_list[i] = (
+                    correct_sfunc_orthogonal_and_set_startInd(
+                        contour,
+                        self.sfunc_orthogonal_list[i],
+                    )
                 )
 
             if upper_wall:
@@ -1699,18 +1699,18 @@ class MeshRegion:
                 next_region.poloidal_distance = MultiLocationArray(
                     next_region.nx, next_region.ny
                 )
-                next_region.poloidal_distance.centre[
-                    :, :
-                ] = region.poloidal_distance.ylow[:, -1, numpy.newaxis]
-                next_region.poloidal_distance.ylow[
-                    :, :
-                ] = region.poloidal_distance.ylow[:, -1, numpy.newaxis]
-                next_region.poloidal_distance.xlow[
-                    :, :
-                ] = region.poloidal_distance.corners[:, -1, numpy.newaxis]
-                next_region.poloidal_distance.corners[
-                    :, :
-                ] = region.poloidal_distance.corners[:, -1, numpy.newaxis]
+                next_region.poloidal_distance.centre[:, :] = (
+                    region.poloidal_distance.ylow[:, -1, numpy.newaxis]
+                )
+                next_region.poloidal_distance.ylow[:, :] = (
+                    region.poloidal_distance.ylow[:, -1, numpy.newaxis]
+                )
+                next_region.poloidal_distance.xlow[:, :] = (
+                    region.poloidal_distance.corners[:, -1, numpy.newaxis]
+                )
+                next_region.poloidal_distance.corners[:, :] = (
+                    region.poloidal_distance.corners[:, -1, numpy.newaxis]
+                )
                 region = next_region
 
         # Save total poloidal distance in core
@@ -2895,12 +2895,12 @@ class Mesh:
                     marky[region_name].centre[1:-1, 1:-1] = this_marky
 
                     if region.connections["inner"] is not None:
-                        markx[region.connections["inner"]].centre[
-                            -1, 1:-1
-                        ] = this_markx[0, :]
-                        marky[region.connections["inner"]].centre[
-                            -1, 1:-1
-                        ] = this_marky[0, :]
+                        markx[region.connections["inner"]].centre[-1, 1:-1] = (
+                            this_markx[0, :]
+                        )
+                        marky[region.connections["inner"]].centre[-1, 1:-1] = (
+                            this_marky[0, :]
+                        )
                     if region.connections["outer"] is not None:
                         markx[region.connections["outer"]].centre[0, 1:-1] = this_markx[
                             -1, :
@@ -2909,12 +2909,12 @@ class Mesh:
                             -1, :
                         ]
                     if region.connections["lower"] is not None:
-                        markx[region.connections["lower"]].centre[
-                            1:-1, -1
-                        ] = this_markx[:, 0]
-                        marky[region.connections["lower"]].centre[
-                            1:-1, -1
-                        ] = this_marky[:, 0]
+                        markx[region.connections["lower"]].centre[1:-1, -1] = (
+                            this_markx[:, 0]
+                        )
+                        marky[region.connections["lower"]].centre[1:-1, -1] = (
+                            this_marky[:, 0]
+                        )
                     if region.connections["upper"] is not None:
                         markx[region.connections["upper"]].centre[1:-1, 0] = this_markx[
                             :, -1
@@ -3022,33 +3022,33 @@ class Mesh:
                     marky[region_name].corners[1:-1, 1:-1] = this_marky
 
                     if region.connections["inner"] is not None:
-                        markx[region.connections["inner"]].corners[
-                            -1, 1:-1
-                        ] = this_markx[0, :]
-                        marky[region.connections["inner"]].corners[
-                            -1, 1:-1
-                        ] = this_marky[0, :]
+                        markx[region.connections["inner"]].corners[-1, 1:-1] = (
+                            this_markx[0, :]
+                        )
+                        marky[region.connections["inner"]].corners[-1, 1:-1] = (
+                            this_marky[0, :]
+                        )
                     if region.connections["outer"] is not None:
-                        markx[region.connections["outer"]].corners[
-                            0, 1:-1
-                        ] = this_markx[-1, :]
-                        marky[region.connections["outer"]].corners[
-                            0, 1:-1
-                        ] = this_marky[-1, :]
+                        markx[region.connections["outer"]].corners[0, 1:-1] = (
+                            this_markx[-1, :]
+                        )
+                        marky[region.connections["outer"]].corners[0, 1:-1] = (
+                            this_marky[-1, :]
+                        )
                     if region.connections["lower"] is not None:
-                        markx[region.connections["lower"]].corners[
-                            1:-1, -1
-                        ] = this_markx[:, 0]
-                        marky[region.connections["lower"]].corners[
-                            1:-1, -1
-                        ] = this_marky[:, 0]
+                        markx[region.connections["lower"]].corners[1:-1, -1] = (
+                            this_markx[:, 0]
+                        )
+                        marky[region.connections["lower"]].corners[1:-1, -1] = (
+                            this_marky[:, 0]
+                        )
                     if region.connections["upper"] is not None:
-                        markx[region.connections["upper"]].corners[
-                            1:-1, 0
-                        ] = this_markx[:, -1]
-                        marky[region.connections["upper"]].corners[
-                            1:-1, 0
-                        ] = this_marky[:, -1]
+                        markx[region.connections["upper"]].corners[1:-1, 0] = (
+                            this_markx[:, -1]
+                        )
+                        marky[region.connections["upper"]].corners[1:-1, 0] = (
+                            this_marky[:, -1]
+                        )
 
             changes = []
             tmp = {}
@@ -3522,9 +3522,9 @@ class BoutMesh(Mesh):
         self.region_indices = {}
         for reg_name in self.equilibrium.regions:
             for i in range(len(x_regions)):
-                self.region_indices[
-                    self.region_lookup[(reg_name, i)]
-                ] = numpy.index_exp[x_regions[i], y_regions[reg_name]]
+                self.region_indices[self.region_lookup[(reg_name, i)]] = (
+                    numpy.index_exp[x_regions[i], y_regions[reg_name]]
+                )
 
         # constant spacing in y for now
         if self.ny_core > 0:
@@ -3563,15 +3563,15 @@ class BoutMesh(Mesh):
                     ]
                 if all_corners:
                     if f_region._corners_array is not None:
-                        f.lower_right_corners[
-                            self.region_indices[region.myID]
-                        ] = f_region.corners[1:, :-1]
-                        f.upper_right_corners[
-                            self.region_indices[region.myID]
-                        ] = f_region.corners[1:, 1:]
-                        f.upper_left_corners[
-                            self.region_indices[region.myID]
-                        ] = f_region.corners[:-1, 1:]
+                        f.lower_right_corners[self.region_indices[region.myID]] = (
+                            f_region.corners[1:, :-1]
+                        )
+                        f.upper_right_corners[self.region_indices[region.myID]] = (
+                            f_region.corners[1:, 1:]
+                        )
+                        f.upper_left_corners[self.region_indices[region.myID]] = (
+                            f_region.corners[:-1, 1:]
+                        )
 
             # Set 'bout_type' so it gets saved in the grid file
             f.attributes["bout_type"] = "Field2D"

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -3019,17 +3019,59 @@ class Mesh:
             if change < 1.0e-3:
                 break
 
-    def plotGridLines(self, **kwargs):
+    def plotGridCellEdges(self, ax=None, **kwargs):
+        """
+        Plot lines between cell corners
+        """
         from matplotlib import pyplot
         from cycler import cycle
 
         colors = cycle(pyplot.rcParams["axes.prop_cycle"].by_key()["color"])
 
+        if ax is None:
+            fig, ax = pyplot.subplots(1)
+        else:
+            fig = ax.figure
+
+        for region in self.regions.values():
+            c = next(colors)
+            label = region.myID
+            for i in range(region.nx + 1):
+                ax.plot(
+                    region.Rxy.corners[i, :],
+                    region.Zxy.corners[i, :],
+                    c=c,
+                    label=label,
+                    **kwargs,
+                )
+                label = None
+            label = region.myID
+            for j in range(region.ny + 1):
+                ax.plot(
+                    region.Rxy.corners[:, j],
+                    region.Zxy.corners[:, j],
+                    c=c,
+                    label=None,
+                    **kwargs,
+                )
+                label = None
+
+    def plotGridLines(self, ax=None, **kwargs):
+        from matplotlib import pyplot
+        from cycler import cycle
+
+        colors = cycle(pyplot.rcParams["axes.prop_cycle"].by_key()["color"])
+
+        if ax is None:
+            fig, ax = pyplot.subplots(1)
+        else:
+            fig = ax.figure
+
         for region in self.regions.values():
             c = next(colors)
             label = region.myID
             for i in range(region.nx):
-                pyplot.plot(
+                ax.plot(
                     region.Rxy.centre[i, :],
                     region.Zxy.centre[i, :],
                     c=c,
@@ -3039,7 +3081,7 @@ class Mesh:
                 label = None
             label = region.myID
             for j in range(region.ny):
-                pyplot.plot(
+                ax.plot(
                     region.Rxy.centre[:, j],
                     region.Zxy.centre[:, j],
                     c=c,
@@ -3047,11 +3089,12 @@ class Mesh:
                     **kwargs,
                 )
                 label = None
-        l = pyplot.legend()
+        l = fig.legend()
         l.set_draggable(True)
 
     def plotPoints(
         self,
+        centers=True,
         xlow=False,
         ylow=False,
         corners=False,
@@ -3092,14 +3135,15 @@ class Mesh:
 
             if "scatter" in plot_types:
                 m = iter(markers)
-                ax.scatter(
-                    region.Rxy.centre,
-                    region.Zxy.centre,
-                    marker=next(m),
-                    c=c,
-                    label=region.myID,
-                    **kwargs,
-                )
+                if centers:
+                    ax.scatter(
+                        region.Rxy.centre,
+                        region.Zxy.centre,
+                        marker=next(m),
+                        c=c,
+                        label=region.myID,
+                        **kwargs,
+                    )
                 if xlow:
                     ax.scatter(
                         region.Rxy.xlow, region.Zxy.xlow, marker=next(m), c=c, **kwargs

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -52,11 +52,14 @@ DEFAULT_OPTIONS = {
 
 DEFAULT_GUI_OPTIONS = {
     "grid_file": "bout.grd.nc",
+    "plot_centers": True,
     "plot_xlow": True,
     "plot_ylow": True,
     "plot_corners": True,
     "save_full_yaml": False,
     "plot_legend": True,
+    "plot_gridlines": False,
+    "plot_celledges": False,
 }
 
 
@@ -134,6 +137,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         set_triggered(self.action_Corners, trigger_replot)
         set_triggered(self.action_Xlow, trigger_replot)
         set_triggered(self.action_Ylow, trigger_replot)
+        set_triggered(self.action_Lines, trigger_replot)
         set_triggered(self.action_Edges, trigger_replot)
         set_triggered(self.action_Legend, trigger_replot)
 
@@ -169,19 +173,25 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         """
         Updates menu items from gui_options
         """
+        self.action_Centers.setChecked(self.gui_options["plot_centers"])
         self.action_Xlow.setChecked(self.gui_options["plot_xlow"])
         self.action_Ylow.setChecked(self.gui_options["plot_ylow"])
         self.action_Corners.setChecked(self.gui_options["plot_corners"])
         self.action_Legend.setChecked(self.gui_options["plot_legend"])
+        self.action_Lines.setChecked(self.gui_options["plot_gridlines"])
+        self.action_Edges.setChecked(self.gui_options["plot_celledges"])
 
     def updateGuiOptionsFromMenu(self):
         """
         Update gui_options settings from menu
         """
+        self.gui_options["plot_centers"] = self.action_Centers.isChecked()
         self.gui_options["plot_xlow"] = self.action_Xlow.isChecked()
         self.gui_options["plot_ylow"] = self.action_Ylow.isChecked()
         self.gui_options["plot_corners"] = self.action_Corners.isChecked()
         self.gui_options["plot_legend"] = self.action_Legend.isChecked()
+        self.gui_options["plot_gridlines"] = self.action_Lines.isChecked()
+        self.gui_options["plot_celledges"] = self.action_Edges.isChecked()
 
     def close(self):
         # Delete and garbage-collect hypnotoad objects here so that any ParallelMap
@@ -639,11 +649,19 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         if hasattr(self, "mesh"):
             # mesh exists, so plot the grid points
             self.mesh.plotPoints(
+                centers=self.gui_options["plot_centers"],
                 xlow=self.gui_options["plot_xlow"],
                 ylow=self.gui_options["plot_ylow"],
                 corners=self.gui_options["plot_corners"],
                 ax=self.plot_widget.axes,
             )
+
+            if self.gui_options["plot_gridlines"]:
+                self.mesh.plotGridLines(ax=self.plot_widget.axes)
+
+            if self.gui_options["plot_celledges"]:
+                self.mesh.plotGridCellEdges(ax=self.plot_widget.axes)
+
         elif hasattr(self, "eq"):
             # no mesh, but do have equilibrium, so plot separatrices
             for region in self.eq.regions.values():

--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -742,9 +742,9 @@ class Preferences(QDialog, Ui_Preferences):
         self.parent.gui_options["plot_xlow"] = self.plotXlowCheckBox.isChecked()
         self.parent.gui_options["plot_ylow"] = self.plotYlowCheckBox.isChecked()
         self.parent.gui_options["plot_corners"] = self.plotCornersCheckBox.isChecked()
-        self.parent.gui_options[
-            "save_full_yaml"
-        ] = self.saveFullYamlCheckBox.isChecked()
+        self.parent.gui_options["save_full_yaml"] = (
+            self.saveFullYamlCheckBox.isChecked()
+        )
 
         self.parent.updateMenuFromGuiOptions()
 

--- a/hypnotoad/gui/hypnotoad_mainWindow.py
+++ b/hypnotoad/gui/hypnotoad_mainWindow.py
@@ -3,250 +3,277 @@
 ################################################################################
 ## Form generated from reading UI file 'hypnotoad_mainWindow.ui'
 ##
-## Created by: Qt User Interface Compiler version 5.14.2
+## Created by: Qt User Interface Compiler version 5.15.2
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
 
-from Qt.QtCore import (QCoreApplication, QDate, QDateTime, QMetaObject,
-    QObject, QPoint, QRect, QSize, QTime, QUrl, Qt)
-from Qt.QtGui import (QBrush, QColor, QConicalGradient, QCursor, QFont,
-    QFontDatabase, QIcon, QKeySequence, QLinearGradient, QPalette, QPainter,
-    QPixmap, QRadialGradient)
-from Qt.QtWidgets import *
+from PySide2.QtCore import *
+from PySide2.QtGui import *
+from PySide2.QtWidgets import *
 
 
 class Ui_Hypnotoad(object):
     def setupUi(self, Hypnotoad):
         if not Hypnotoad.objectName():
-            Hypnotoad.setObjectName(u"Hypnotoad")
+            Hypnotoad.setObjectName("Hypnotoad")
         Hypnotoad.resize(1215, 863)
         self.action_New = QAction(Hypnotoad)
-        self.action_New.setObjectName(u"action_New")
+        self.action_New.setObjectName("action_New")
         icon = QIcon()
-        iconThemeName = u"document-new"
+        iconThemeName = "document-new"
         if QIcon.hasThemeIcon(iconThemeName):
             icon = QIcon.fromTheme(iconThemeName)
         else:
-            icon.addFile(u".", QSize(), QIcon.Normal, QIcon.Off)
+            icon.addFile(".", QSize(), QIcon.Normal, QIcon.Off)
 
         self.action_New.setIcon(icon)
         self.action_Open = QAction(Hypnotoad)
-        self.action_Open.setObjectName(u"action_Open")
+        self.action_Open.setObjectName("action_Open")
         icon1 = QIcon()
-        iconThemeName = u"document-open"
+        iconThemeName = "document-open"
         if QIcon.hasThemeIcon(iconThemeName):
             icon1 = QIcon.fromTheme(iconThemeName)
         else:
-            icon1.addFile(u".", QSize(), QIcon.Normal, QIcon.Off)
+            icon1.addFile(".", QSize(), QIcon.Normal, QIcon.Off)
 
         self.action_Open.setIcon(icon1)
         self.action_Save = QAction(Hypnotoad)
-        self.action_Save.setObjectName(u"action_Save")
+        self.action_Save.setObjectName("action_Save")
         icon2 = QIcon()
-        iconThemeName = u"document-save"
+        iconThemeName = "document-save"
         if QIcon.hasThemeIcon(iconThemeName):
             icon2 = QIcon.fromTheme(iconThemeName)
         else:
-            icon2.addFile(u".", QSize(), QIcon.Normal, QIcon.Off)
+            icon2.addFile(".", QSize(), QIcon.Normal, QIcon.Off)
 
         self.action_Save.setIcon(icon2)
         self.action_Save_as = QAction(Hypnotoad)
-        self.action_Save_as.setObjectName(u"action_Save_as")
+        self.action_Save_as.setObjectName("action_Save_as")
         icon3 = QIcon()
-        iconThemeName = u"document-save-as"
+        iconThemeName = "document-save-as"
         if QIcon.hasThemeIcon(iconThemeName):
             icon3 = QIcon.fromTheme(iconThemeName)
         else:
-            icon3.addFile(u".", QSize(), QIcon.Normal, QIcon.Off)
+            icon3.addFile(".", QSize(), QIcon.Normal, QIcon.Off)
 
         self.action_Save_as.setIcon(icon3)
         self.action_Quit = QAction(Hypnotoad)
-        self.action_Quit.setObjectName(u"action_Quit")
+        self.action_Quit.setObjectName("action_Quit")
         icon4 = QIcon()
-        iconThemeName = u"application-exit"
+        iconThemeName = "application-exit"
         if QIcon.hasThemeIcon(iconThemeName):
             icon4 = QIcon.fromTheme(iconThemeName)
         else:
-            icon4.addFile(u".", QSize(), QIcon.Normal, QIcon.Off)
+            icon4.addFile(".", QSize(), QIcon.Normal, QIcon.Off)
 
         self.action_Quit.setIcon(icon4)
         self.action_About = QAction(Hypnotoad)
-        self.action_About.setObjectName(u"action_About")
+        self.action_About.setObjectName("action_About")
         icon5 = QIcon()
-        iconThemeName = u"help-about"
+        iconThemeName = "help-about"
         if QIcon.hasThemeIcon(iconThemeName):
             icon5 = QIcon.fromTheme(iconThemeName)
         else:
-            icon5.addFile(u".", QSize(), QIcon.Normal, QIcon.Off)
+            icon5.addFile(".", QSize(), QIcon.Normal, QIcon.Off)
 
         self.action_About.setIcon(icon5)
         self.action_Run = QAction(Hypnotoad)
-        self.action_Run.setObjectName(u"action_Run")
+        self.action_Run.setObjectName("action_Run")
         icon6 = QIcon()
-        iconThemeName = u"system-run"
+        iconThemeName = "system-run"
         if QIcon.hasThemeIcon(iconThemeName):
             icon6 = QIcon.fromTheme(iconThemeName)
         else:
-            icon6.addFile(u".", QSize(), QIcon.Normal, QIcon.Off)
+            icon6.addFile(".", QSize(), QIcon.Normal, QIcon.Off)
 
         self.action_Run.setIcon(icon6)
         self.action_Write_grid = QAction(Hypnotoad)
-        self.action_Write_grid.setObjectName(u"action_Write_grid")
+        self.action_Write_grid.setObjectName("action_Write_grid")
         icon7 = QIcon()
-        iconThemeName = u"document-print"
+        iconThemeName = "document-print"
         if QIcon.hasThemeIcon(iconThemeName):
             icon7 = QIcon.fromTheme(iconThemeName)
         else:
-            icon7.addFile(u".", QSize(), QIcon.Normal, QIcon.Off)
+            icon7.addFile(".", QSize(), QIcon.Normal, QIcon.Off)
 
         self.action_Write_grid.setIcon(icon7)
         self.action_Revert = QAction(Hypnotoad)
-        self.action_Revert.setObjectName(u"action_Revert")
+        self.action_Revert.setObjectName("action_Revert")
         icon8 = QIcon()
-        iconThemeName = u"document-revert"
+        iconThemeName = "document-revert"
         if QIcon.hasThemeIcon(iconThemeName):
             icon8 = QIcon.fromTheme(iconThemeName)
         else:
-            icon8.addFile(u".", QSize(), QIcon.Normal, QIcon.Off)
+            icon8.addFile(".", QSize(), QIcon.Normal, QIcon.Off)
 
         self.action_Revert.setIcon(icon8)
         self.action_Preferences = QAction(Hypnotoad)
-        self.action_Preferences.setObjectName(u"action_Preferences")
-        icon9 = QIcon(QIcon.fromTheme(u"document-properties"))
+        self.action_Preferences.setObjectName("action_Preferences")
+        icon9 = QIcon(QIcon.fromTheme("document-properties"))
         self.action_Preferences.setIcon(icon9)
         self.action_Regrid = QAction(Hypnotoad)
-        self.action_Regrid.setObjectName(u"action_Regrid")
+        self.action_Regrid.setObjectName("action_Regrid")
         self.action_Regrid.setEnabled(False)
         self.action_Regrid.setIcon(icon6)
+        self.action_Flux = QAction(Hypnotoad)
+        self.action_Flux.setObjectName("action_Flux")
+        self.action_Flux.setCheckable(True)
+        self.action_Flux.setChecked(True)
+        self.action_Wall = QAction(Hypnotoad)
+        self.action_Wall.setObjectName("action_Wall")
+        self.action_Wall.setCheckable(True)
+        self.action_Wall.setChecked(True)
+        self.action_Centers = QAction(Hypnotoad)
+        self.action_Centers.setObjectName("action_Centers")
+        self.action_Centers.setCheckable(True)
+        self.action_Centers.setChecked(True)
+        self.action_Corners = QAction(Hypnotoad)
+        self.action_Corners.setObjectName("action_Corners")
+        self.action_Corners.setCheckable(True)
+        self.action_Corners.setChecked(True)
+        self.action_Xlow = QAction(Hypnotoad)
+        self.action_Xlow.setObjectName("action_Xlow")
+        self.action_Xlow.setCheckable(True)
+        self.action_Xlow.setChecked(True)
+        self.action_Ylow = QAction(Hypnotoad)
+        self.action_Ylow.setObjectName("action_Ylow")
+        self.action_Ylow.setCheckable(True)
+        self.action_Ylow.setChecked(True)
+        self.action_Edges = QAction(Hypnotoad)
+        self.action_Edges.setObjectName("action_Edges")
+        self.action_Edges.setCheckable(True)
+        self.action_Legend = QAction(Hypnotoad)
+        self.action_Legend.setObjectName("action_Legend")
+        self.action_Legend.setCheckable(True)
         self.centralwidget = QWidget(Hypnotoad)
-        self.centralwidget.setObjectName(u"centralwidget")
+        self.centralwidget.setObjectName("centralwidget")
         self.horizontalLayout_2 = QHBoxLayout(self.centralwidget)
-        self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
+        self.horizontalLayout_2.setObjectName("horizontalLayout_2")
         self.horizontalLayout = QHBoxLayout()
-        self.horizontalLayout.setObjectName(u"horizontalLayout")
+        self.horizontalLayout.setObjectName("horizontalLayout")
         self.verticalLayout_2 = QVBoxLayout()
-        self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.verticalLayout_2.setObjectName("verticalLayout_2")
         self.search_bar = QLineEdit(self.centralwidget)
-        self.search_bar.setObjectName(u"search_bar")
+        self.search_bar.setObjectName("search_bar")
 
         self.verticalLayout_2.addWidget(self.search_bar)
 
         self.options_form = QTableWidget(self.centralwidget)
-        if (self.options_form.columnCount() < 2):
+        if self.options_form.columnCount() < 2:
             self.options_form.setColumnCount(2)
         __qtablewidgetitem = QTableWidgetItem()
         self.options_form.setHorizontalHeaderItem(0, __qtablewidgetitem)
         __qtablewidgetitem1 = QTableWidgetItem()
         self.options_form.setHorizontalHeaderItem(1, __qtablewidgetitem1)
-        self.options_form.setObjectName(u"options_form")
+        self.options_form.setObjectName("options_form")
 
         self.verticalLayout_2.addWidget(self.options_form)
 
         self.gridLayout_2 = QGridLayout()
-        self.gridLayout_2.setObjectName(u"gridLayout_2")
+        self.gridLayout_2.setObjectName("gridLayout_2")
         self.options_file_browse_button = QPushButton(self.centralwidget)
-        self.options_file_browse_button.setObjectName(u"options_file_browse_button")
+        self.options_file_browse_button.setObjectName("options_file_browse_button")
 
         self.gridLayout_2.addWidget(self.options_file_browse_button, 0, 2, 1, 1)
 
         self.geqdsk_file_browse_button = QPushButton(self.centralwidget)
-        self.geqdsk_file_browse_button.setObjectName(u"geqdsk_file_browse_button")
+        self.geqdsk_file_browse_button.setObjectName("geqdsk_file_browse_button")
 
         self.gridLayout_2.addWidget(self.geqdsk_file_browse_button, 0, 6, 1, 1)
 
         self.options_file_line_edit = QLineEdit(self.centralwidget)
-        self.options_file_line_edit.setObjectName(u"options_file_line_edit")
+        self.options_file_line_edit.setObjectName("options_file_line_edit")
 
         self.gridLayout_2.addWidget(self.options_file_line_edit, 0, 1, 1, 1)
 
         self.run_button = QPushButton(self.centralwidget)
-        self.run_button.setObjectName(u"run_button")
+        self.run_button.setObjectName("run_button")
 
         self.gridLayout_2.addWidget(self.run_button, 0, 7, 1, 1)
 
         self.write_grid_button = QPushButton(self.centralwidget)
-        self.write_grid_button.setObjectName(u"write_grid_button")
+        self.write_grid_button.setObjectName("write_grid_button")
 
         self.gridLayout_2.addWidget(self.write_grid_button, 0, 9, 1, 1)
 
         self.geqdsk_file_line_edit = QLineEdit(self.centralwidget)
-        self.geqdsk_file_line_edit.setObjectName(u"geqdsk_file_line_edit")
+        self.geqdsk_file_line_edit.setObjectName("geqdsk_file_line_edit")
 
         self.gridLayout_2.addWidget(self.geqdsk_file_line_edit, 0, 4, 1, 1)
 
         self.geqdsk_file_label = QLabel(self.centralwidget)
-        self.geqdsk_file_label.setObjectName(u"geqdsk_file_label")
+        self.geqdsk_file_label.setObjectName("geqdsk_file_label")
 
         self.gridLayout_2.addWidget(self.geqdsk_file_label, 0, 3, 1, 1)
 
         self.options_file_label = QLabel(self.centralwidget)
-        self.options_file_label.setObjectName(u"options_file_label")
+        self.options_file_label.setObjectName("options_file_label")
 
         self.gridLayout_2.addWidget(self.options_file_label, 0, 0, 1, 1)
 
         self.regrid_button = QPushButton(self.centralwidget)
-        self.regrid_button.setObjectName(u"regrid_button")
+        self.regrid_button.setObjectName("regrid_button")
         self.regrid_button.setEnabled(False)
 
         self.gridLayout_2.addWidget(self.regrid_button, 1, 7, 1, 1)
 
         self.nonorthogonal_box = QCheckBox(self.centralwidget)
-        self.nonorthogonal_box.setObjectName(u"nonorthogonal_box")
+        self.nonorthogonal_box.setObjectName("nonorthogonal_box")
         self.nonorthogonal_box.setEnabled(True)
 
         self.gridLayout_2.addWidget(self.nonorthogonal_box, 1, 6, 1, 1)
 
-
         self.verticalLayout_2.addLayout(self.gridLayout_2)
 
         self.horizontalLayout_4 = QHBoxLayout()
-        self.horizontalLayout_4.setObjectName(u"horizontalLayout_4")
+        self.horizontalLayout_4.setObjectName("horizontalLayout_4")
 
         self.verticalLayout_2.addLayout(self.horizontalLayout_4)
 
         self.gridLayout = QGridLayout()
-        self.gridLayout.setObjectName(u"gridLayout")
+        self.gridLayout.setObjectName("gridLayout")
 
         self.verticalLayout_2.addLayout(self.gridLayout)
-
 
         self.horizontalLayout.addLayout(self.verticalLayout_2)
 
         self.plottingArea = QWidget(self.centralwidget)
-        self.plottingArea.setObjectName(u"plottingArea")
+        self.plottingArea.setObjectName("plottingArea")
 
         self.horizontalLayout.addWidget(self.plottingArea)
-
 
         self.horizontalLayout_2.addLayout(self.horizontalLayout)
 
         Hypnotoad.setCentralWidget(self.centralwidget)
         self.menubar = QMenuBar(Hypnotoad)
-        self.menubar.setObjectName(u"menubar")
+        self.menubar.setObjectName("menubar")
         self.menubar.setGeometry(QRect(0, 0, 1215, 22))
         self.menu_File = QMenu(self.menubar)
-        self.menu_File.setObjectName(u"menu_File")
+        self.menu_File.setObjectName("menu_File")
         self.menu_Help = QMenu(self.menubar)
-        self.menu_Help.setObjectName(u"menu_Help")
+        self.menu_Help.setObjectName("menu_Help")
         self.menu_Mesh = QMenu(self.menubar)
-        self.menu_Mesh.setObjectName(u"menu_Mesh")
+        self.menu_Mesh.setObjectName("menu_Mesh")
+        self.menu_View = QMenu(self.menubar)
+        self.menu_View.setObjectName("menu_View")
         Hypnotoad.setMenuBar(self.menubar)
         self.statusbar = QStatusBar(Hypnotoad)
-        self.statusbar.setObjectName(u"statusbar")
+        self.statusbar.setObjectName("statusbar")
         Hypnotoad.setStatusBar(self.statusbar)
         self.toolBar = QToolBar(Hypnotoad)
-        self.toolBar.setObjectName(u"toolBar")
+        self.toolBar.setObjectName("toolBar")
         Hypnotoad.addToolBar(Qt.TopToolBarArea, self.toolBar)
         self.toolBar_2 = QToolBar(Hypnotoad)
-        self.toolBar_2.setObjectName(u"toolBar_2")
+        self.toolBar_2.setObjectName("toolBar_2")
         Hypnotoad.addToolBar(Qt.TopToolBarArea, self.toolBar_2)
         self.toolBar_3 = QToolBar(Hypnotoad)
-        self.toolBar_3.setObjectName(u"toolBar_3")
+        self.toolBar_3.setObjectName("toolBar_3")
         Hypnotoad.addToolBar(Qt.TopToolBarArea, self.toolBar_3)
 
         self.menubar.addAction(self.menu_File.menuAction())
         self.menubar.addAction(self.menu_Mesh.menuAction())
+        self.menubar.addAction(self.menu_View.menuAction())
         self.menubar.addAction(self.menu_Help.menuAction())
         self.menu_File.addAction(self.action_New)
         self.menu_File.addAction(self.action_Open)
@@ -260,6 +287,14 @@ class Ui_Hypnotoad(object):
         self.menu_Mesh.addAction(self.action_Run)
         self.menu_Mesh.addAction(self.action_Regrid)
         self.menu_Mesh.addAction(self.action_Write_grid)
+        self.menu_View.addAction(self.action_Flux)
+        self.menu_View.addAction(self.action_Wall)
+        self.menu_View.addAction(self.action_Centers)
+        self.menu_View.addAction(self.action_Corners)
+        self.menu_View.addAction(self.action_Xlow)
+        self.menu_View.addAction(self.action_Ylow)
+        self.menu_View.addAction(self.action_Edges)
+        self.menu_View.addAction(self.action_Legend)
         self.toolBar.addAction(self.action_New)
         self.toolBar.addAction(self.action_Open)
         self.toolBar.addAction(self.action_Save)
@@ -270,64 +305,201 @@ class Ui_Hypnotoad(object):
         self.retranslateUi(Hypnotoad)
 
         QMetaObject.connectSlotsByName(Hypnotoad)
+
     # setupUi
 
     def retranslateUi(self, Hypnotoad):
-        Hypnotoad.setWindowTitle(QCoreApplication.translate("Hypnotoad", u"MainWindow", None))
-        self.action_New.setText(QCoreApplication.translate("Hypnotoad", u"&New", None))
-#if QT_CONFIG(shortcut)
-        self.action_New.setShortcut(QCoreApplication.translate("Hypnotoad", u"Ctrl+N", None))
-#endif // QT_CONFIG(shortcut)
-        self.action_Open.setText(QCoreApplication.translate("Hypnotoad", u"&Open", None))
-#if QT_CONFIG(shortcut)
-        self.action_Open.setShortcut(QCoreApplication.translate("Hypnotoad", u"Ctrl+O", None))
-#endif // QT_CONFIG(shortcut)
-        self.action_Save.setText(QCoreApplication.translate("Hypnotoad", u"&Save", None))
-#if QT_CONFIG(tooltip)
-        self.action_Save.setToolTip(QCoreApplication.translate("Hypnotoad", u"Save", None))
-#endif // QT_CONFIG(tooltip)
-#if QT_CONFIG(shortcut)
-        self.action_Save.setShortcut(QCoreApplication.translate("Hypnotoad", u"Ctrl+S", None))
-#endif // QT_CONFIG(shortcut)
-        self.action_Save_as.setText(QCoreApplication.translate("Hypnotoad", u"Save as", None))
-#if QT_CONFIG(shortcut)
-        self.action_Save_as.setShortcut(QCoreApplication.translate("Hypnotoad", u"Ctrl+Shift+S", None))
-#endif // QT_CONFIG(shortcut)
-        self.action_Quit.setText(QCoreApplication.translate("Hypnotoad", u"&Quit", None))
-#if QT_CONFIG(shortcut)
-        self.action_Quit.setShortcut(QCoreApplication.translate("Hypnotoad", u"Ctrl+Q", None))
-#endif // QT_CONFIG(shortcut)
-        self.action_About.setText(QCoreApplication.translate("Hypnotoad", u"&About", None))
-        self.action_Run.setText(QCoreApplication.translate("Hypnotoad", u"&Run", None))
-#if QT_CONFIG(shortcut)
-        self.action_Run.setShortcut(QCoreApplication.translate("Hypnotoad", u"Ctrl+R", None))
-#endif // QT_CONFIG(shortcut)
-        self.action_Write_grid.setText(QCoreApplication.translate("Hypnotoad", u"&Write grid", None))
-#if QT_CONFIG(shortcut)
-        self.action_Write_grid.setShortcut(QCoreApplication.translate("Hypnotoad", u"Ctrl+W", None))
-#endif // QT_CONFIG(shortcut)
-        self.action_Revert.setText(QCoreApplication.translate("Hypnotoad", u"&Revert", None))
-        self.action_Preferences.setText(QCoreApplication.translate("Hypnotoad", u"&Preferences...", None))
-        self.action_Regrid.setText(QCoreApplication.translate("Hypnotoad", u"Re&grid", None))
-        self.action_Regrid.setToolTip(QCoreApplication.translate("Hypnotoad", u"Regrid non-orthogonal mesh", None))
+        Hypnotoad.setWindowTitle(
+            QCoreApplication.translate("Hypnotoad", "MainWindow", None)
+        )
+        self.action_New.setText(QCoreApplication.translate("Hypnotoad", "&New", None))
+        # if QT_CONFIG(shortcut)
+        self.action_New.setShortcut(
+            QCoreApplication.translate("Hypnotoad", "Ctrl+N", None)
+        )
+        # endif // QT_CONFIG(shortcut)
+        self.action_Open.setText(QCoreApplication.translate("Hypnotoad", "&Open", None))
+        # if QT_CONFIG(shortcut)
+        self.action_Open.setShortcut(
+            QCoreApplication.translate("Hypnotoad", "Ctrl+O", None)
+        )
+        # endif // QT_CONFIG(shortcut)
+        self.action_Save.setText(QCoreApplication.translate("Hypnotoad", "&Save", None))
+        # if QT_CONFIG(tooltip)
+        self.action_Save.setToolTip(
+            QCoreApplication.translate("Hypnotoad", "Save", None)
+        )
+        # endif // QT_CONFIG(tooltip)
+        # if QT_CONFIG(shortcut)
+        self.action_Save.setShortcut(
+            QCoreApplication.translate("Hypnotoad", "Ctrl+S", None)
+        )
+        # endif // QT_CONFIG(shortcut)
+        self.action_Save_as.setText(
+            QCoreApplication.translate("Hypnotoad", "Save as", None)
+        )
+        # if QT_CONFIG(shortcut)
+        self.action_Save_as.setShortcut(
+            QCoreApplication.translate("Hypnotoad", "Ctrl+Shift+S", None)
+        )
+        # endif // QT_CONFIG(shortcut)
+        self.action_Quit.setText(QCoreApplication.translate("Hypnotoad", "&Quit", None))
+        # if QT_CONFIG(shortcut)
+        self.action_Quit.setShortcut(
+            QCoreApplication.translate("Hypnotoad", "Ctrl+Q", None)
+        )
+        # endif // QT_CONFIG(shortcut)
+        self.action_About.setText(
+            QCoreApplication.translate("Hypnotoad", "&About", None)
+        )
+        self.action_Run.setText(QCoreApplication.translate("Hypnotoad", "&Run", None))
+        # if QT_CONFIG(shortcut)
+        self.action_Run.setShortcut(
+            QCoreApplication.translate("Hypnotoad", "Ctrl+R", None)
+        )
+        # endif // QT_CONFIG(shortcut)
+        self.action_Write_grid.setText(
+            QCoreApplication.translate("Hypnotoad", "&Write grid", None)
+        )
+        # if QT_CONFIG(shortcut)
+        self.action_Write_grid.setShortcut(
+            QCoreApplication.translate("Hypnotoad", "Ctrl+W", None)
+        )
+        # endif // QT_CONFIG(shortcut)
+        self.action_Revert.setText(
+            QCoreApplication.translate("Hypnotoad", "&Revert", None)
+        )
+        self.action_Preferences.setText(
+            QCoreApplication.translate("Hypnotoad", "&Preferences...", None)
+        )
+        self.action_Regrid.setText(
+            QCoreApplication.translate("Hypnotoad", "Re&grid", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.action_Regrid.setToolTip(
+            QCoreApplication.translate("Hypnotoad", "Regrid non-orthogonal mesh", None)
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.action_Flux.setText(
+            QCoreApplication.translate("Hypnotoad", "Poloidal flux", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.action_Flux.setToolTip(
+            QCoreApplication.translate("Hypnotoad", "Plot poloidal flux?", None)
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.action_Wall.setText(QCoreApplication.translate("Hypnotoad", "Wall", None))
+        # if QT_CONFIG(tooltip)
+        self.action_Wall.setToolTip(
+            QCoreApplication.translate("Hypnotoad", "Plot wall?", None)
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.action_Centers.setText(
+            QCoreApplication.translate("Hypnotoad", "Cell centers", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.action_Centers.setToolTip(
+            QCoreApplication.translate("Hypnotoad", "Plot cell centers?", None)
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.action_Corners.setText(
+            QCoreApplication.translate("Hypnotoad", "Cell corners", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.action_Corners.setToolTip(
+            QCoreApplication.translate("Hypnotoad", "Plot cell corners?", None)
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.action_Xlow.setText(
+            QCoreApplication.translate("Hypnotoad", "Cell Xlow", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.action_Xlow.setToolTip(
+            QCoreApplication.translate("Hypnotoad", "Plot cell Xlow locations?", None)
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.action_Ylow.setText(
+            QCoreApplication.translate("Hypnotoad", "Cell Ylow", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.action_Ylow.setToolTip(
+            QCoreApplication.translate("Hypnotoad", "Plot cell Ylow locations?", None)
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.action_Edges.setText(
+            QCoreApplication.translate("Hypnotoad", "Cell edges", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.action_Edges.setToolTip(
+            QCoreApplication.translate("Hypnotoad", "Plot cell edges?", None)
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.action_Legend.setText(
+            QCoreApplication.translate("Hypnotoad", "Legend", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.action_Legend.setToolTip(
+            QCoreApplication.translate("Hypnotoad", "Plot legend?", None)
+        )
+        # endif // QT_CONFIG(tooltip)
         ___qtablewidgetitem = self.options_form.horizontalHeaderItem(0)
-        ___qtablewidgetitem.setText(QCoreApplication.translate("Hypnotoad", u"Name", None));
+        ___qtablewidgetitem.setText(
+            QCoreApplication.translate("Hypnotoad", "Name", None)
+        )
         ___qtablewidgetitem1 = self.options_form.horizontalHeaderItem(1)
-        ___qtablewidgetitem1.setText(QCoreApplication.translate("Hypnotoad", u"Value", None));
-        self.options_file_browse_button.setText(QCoreApplication.translate("Hypnotoad", u"Browse", None))
-        self.geqdsk_file_browse_button.setText(QCoreApplication.translate("Hypnotoad", u"Browse", None))
-        self.run_button.setText(QCoreApplication.translate("Hypnotoad", u"Run", None))
-        self.write_grid_button.setText(QCoreApplication.translate("Hypnotoad", u"Write Grid", None))
-        self.geqdsk_file_label.setText(QCoreApplication.translate("Hypnotoad", u"geqdsk file", None))
-        self.options_file_label.setText(QCoreApplication.translate("Hypnotoad", u"Options file", None))
-        self.regrid_button.setToolTip(QCoreApplication.translate("Hypnotoad", u"Recalculate spacing of non-orthogonal grids (check 'Non-Orthogonal' box to activate)", None))
-        self.regrid_button.setText(QCoreApplication.translate("Hypnotoad", u"Regrid", None))
-        self.nonorthogonal_box.setToolTip(QCoreApplication.translate("Hypnotoad", u"Check to generate non-orthogonal grids", None))
-        self.nonorthogonal_box.setText(QCoreApplication.translate("Hypnotoad", u"Non-Orthogonal", None))
-        self.menu_File.setTitle(QCoreApplication.translate("Hypnotoad", u"&File", None))
-        self.menu_Help.setTitle(QCoreApplication.translate("Hypnotoad", u"&Help", None))
-        self.menu_Mesh.setTitle(QCoreApplication.translate("Hypnotoad", u"&Mesh", None))
-        self.toolBar.setWindowTitle(QCoreApplication.translate("Hypnotoad", u"toolBar", None))
-        self.toolBar_2.setWindowTitle(QCoreApplication.translate("Hypnotoad", u"toolBar_2", None))
-        self.toolBar_3.setWindowTitle(QCoreApplication.translate("Hypnotoad", u"toolBar_3", None))
+        ___qtablewidgetitem1.setText(
+            QCoreApplication.translate("Hypnotoad", "Value", None)
+        )
+        self.options_file_browse_button.setText(
+            QCoreApplication.translate("Hypnotoad", "Browse", None)
+        )
+        self.geqdsk_file_browse_button.setText(
+            QCoreApplication.translate("Hypnotoad", "Browse", None)
+        )
+        self.run_button.setText(QCoreApplication.translate("Hypnotoad", "Run", None))
+        self.write_grid_button.setText(
+            QCoreApplication.translate("Hypnotoad", "Write Grid", None)
+        )
+        self.geqdsk_file_label.setText(
+            QCoreApplication.translate("Hypnotoad", "geqdsk file", None)
+        )
+        self.options_file_label.setText(
+            QCoreApplication.translate("Hypnotoad", "Options file", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.regrid_button.setToolTip(
+            QCoreApplication.translate(
+                "Hypnotoad",
+                "Recalculate spacing of non-orthogonal grids (check 'Non-Orthogonal' box to activate)",
+                None,
+            )
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.regrid_button.setText(
+            QCoreApplication.translate("Hypnotoad", "Regrid", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.nonorthogonal_box.setToolTip(
+            QCoreApplication.translate(
+                "Hypnotoad", "Check to generate non-orthogonal grids", None
+            )
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.nonorthogonal_box.setText(
+            QCoreApplication.translate("Hypnotoad", "Non-Orthogonal", None)
+        )
+        self.menu_File.setTitle(QCoreApplication.translate("Hypnotoad", "&File", None))
+        self.menu_Help.setTitle(QCoreApplication.translate("Hypnotoad", "&Help", None))
+        self.menu_Mesh.setTitle(QCoreApplication.translate("Hypnotoad", "&Mesh", None))
+        self.menu_View.setTitle(QCoreApplication.translate("Hypnotoad", "&View", None))
+        self.toolBar.setWindowTitle(
+            QCoreApplication.translate("Hypnotoad", "toolBar", None)
+        )
+        self.toolBar_2.setWindowTitle(
+            QCoreApplication.translate("Hypnotoad", "toolBar_2", None)
+        )
+        self.toolBar_3.setWindowTitle(
+            QCoreApplication.translate("Hypnotoad", "toolBar_3", None)
+        )
+
     # retranslateUi

--- a/hypnotoad/gui/hypnotoad_mainWindow.py
+++ b/hypnotoad/gui/hypnotoad_mainWindow.py
@@ -149,6 +149,11 @@ class Ui_Hypnotoad(object):
         self.action_Legend = QAction(Hypnotoad)
         self.action_Legend.setObjectName("action_Legend")
         self.action_Legend.setCheckable(True)
+        self.action_Penalty = QAction(Hypnotoad)
+        self.action_Penalty.setObjectName("action_Penalty")
+        self.action_Penalty.setCheckable(True)
+        self.action_Clear = QAction(Hypnotoad)
+        self.action_Clear.setObjectName("action_Clear")
         self.centralwidget = QWidget(Hypnotoad)
         self.centralwidget.setObjectName("centralwidget")
         self.horizontalLayout_2 = QHBoxLayout(self.centralwidget)
@@ -299,6 +304,8 @@ class Ui_Hypnotoad(object):
         self.menu_View.addAction(self.action_Lines)
         self.menu_View.addAction(self.action_Edges)
         self.menu_View.addAction(self.action_Legend)
+        self.menu_View.addAction(self.action_Penalty)
+        self.menu_View.addAction(self.action_Clear)
         self.toolBar.addAction(self.action_New)
         self.toolBar.addAction(self.action_Open)
         self.toolBar.addAction(self.action_Save)
@@ -452,6 +459,22 @@ class Ui_Hypnotoad(object):
         # if QT_CONFIG(tooltip)
         self.action_Legend.setToolTip(
             QCoreApplication.translate("Hypnotoad", "Plot legend?", None)
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.action_Penalty.setText(
+            QCoreApplication.translate("Hypnotoad", "Penalty mask", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.action_Penalty.setToolTip(
+            QCoreApplication.translate("Hypnotoad", "Plot penalty mask?", None)
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.action_Clear.setText(
+            QCoreApplication.translate("Hypnotoad", "Clear plot", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.action_Clear.setToolTip(
+            QCoreApplication.translate("Hypnotoad", "Clear grid plot", None)
         )
         # endif // QT_CONFIG(tooltip)
         ___qtablewidgetitem = self.options_form.horizontalHeaderItem(0)

--- a/hypnotoad/gui/hypnotoad_mainWindow.py
+++ b/hypnotoad/gui/hypnotoad_mainWindow.py
@@ -140,6 +140,9 @@ class Ui_Hypnotoad(object):
         self.action_Ylow.setObjectName("action_Ylow")
         self.action_Ylow.setCheckable(True)
         self.action_Ylow.setChecked(True)
+        self.action_Lines = QAction(Hypnotoad)
+        self.action_Lines.setObjectName("action_Lines")
+        self.action_Lines.setCheckable(True)
         self.action_Edges = QAction(Hypnotoad)
         self.action_Edges.setObjectName("action_Edges")
         self.action_Edges.setCheckable(True)
@@ -293,6 +296,7 @@ class Ui_Hypnotoad(object):
         self.menu_View.addAction(self.action_Corners)
         self.menu_View.addAction(self.action_Xlow)
         self.menu_View.addAction(self.action_Ylow)
+        self.menu_View.addAction(self.action_Lines)
         self.menu_View.addAction(self.action_Edges)
         self.menu_View.addAction(self.action_Legend)
         self.toolBar.addAction(self.action_New)
@@ -424,6 +428,14 @@ class Ui_Hypnotoad(object):
         # if QT_CONFIG(tooltip)
         self.action_Ylow.setToolTip(
             QCoreApplication.translate("Hypnotoad", "Plot cell Ylow locations?", None)
+        )
+        # endif // QT_CONFIG(tooltip)
+        self.action_Lines.setText(
+            QCoreApplication.translate("Hypnotoad", "Grid lines", None)
+        )
+        # if QT_CONFIG(tooltip)
+        self.action_Lines.setToolTip(
+            QCoreApplication.translate("Hypnotoad", "Plot grid lines?", None)
         )
         # endif // QT_CONFIG(tooltip)
         self.action_Edges.setText(

--- a/hypnotoad/gui/hypnotoad_mainWindow.py
+++ b/hypnotoad/gui/hypnotoad_mainWindow.py
@@ -8,9 +8,35 @@
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
 
-from PySide2.QtCore import *
-from PySide2.QtGui import *
-from PySide2.QtWidgets import *
+from Qt.QtCore import (
+    QCoreApplication,
+    QDate,
+    QDateTime,
+    QMetaObject,
+    QObject,
+    QPoint,
+    QRect,
+    QSize,
+    QTime,
+    QUrl,
+    Qt,
+)
+from Qt.QtGui import (
+    QBrush,
+    QColor,
+    QConicalGradient,
+    QCursor,
+    QFont,
+    QFontDatabase,
+    QIcon,
+    QKeySequence,
+    QLinearGradient,
+    QPalette,
+    QPainter,
+    QPixmap,
+    QRadialGradient,
+)
+from Qt.QtWidgets import *
 
 
 class Ui_Hypnotoad(object):

--- a/hypnotoad/gui/hypnotoad_mainWindow.ui
+++ b/hypnotoad/gui/hypnotoad_mainWindow.ui
@@ -178,6 +178,8 @@
     <addaction name="action_Lines"/>
     <addaction name="action_Edges"/>
     <addaction name="action_Legend"/>
+    <addaction name="action_Penalty"/>
+    <addaction name="action_Clear"/>
    </widget>
    <addaction name="menu_File"/>
    <addaction name="menu_Mesh"/>
@@ -468,6 +470,25 @@
    </property>
    <property name="toolTip">
     <string>Plot legend?</string>
+   </property>
+  </action>
+  <action name="action_Penalty">
+   <property name="text">
+    <string>Penalty mask</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="toolTip">
+    <string>Plot penalty mask?</string>
+   </property>
+  </action>
+  <action name="action_Clear">
+   <property name="text">
+    <string>Clear plot</string>
+   </property>
+   <property name="toolTip">
+    <string>Clear grid plot</string>
    </property>
   </action>
  </widget>

--- a/hypnotoad/gui/hypnotoad_mainWindow.ui
+++ b/hypnotoad/gui/hypnotoad_mainWindow.ui
@@ -175,6 +175,7 @@
     <addaction name="action_Corners"/>
     <addaction name="action_Xlow"/>
     <addaction name="action_Ylow"/>
+    <addaction name="action_Lines"/>
     <addaction name="action_Edges"/>
     <addaction name="action_Legend"/>
    </widget>
@@ -434,6 +435,17 @@
    </property>
    <property name="toolTip">
     <string>Plot cell Ylow locations?</string>
+   </property>
+  </action>
+  <action name="action_Lines">
+   <property name="text">
+    <string>Grid lines</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="toolTip">
+    <string>Plot grid lines?</string>
    </property>
   </action>
   <action name="action_Edges">

--- a/hypnotoad/gui/hypnotoad_mainWindow.ui
+++ b/hypnotoad/gui/hypnotoad_mainWindow.ui
@@ -165,8 +165,22 @@
     <addaction name="action_Regrid"/>
     <addaction name="action_Write_grid"/>
    </widget>
+   <widget class="QMenu" name="menu_View">
+    <property name="title">
+     <string>&amp;View</string>
+    </property>
+    <addaction name="action_Flux"/>
+    <addaction name="action_Wall"/>
+    <addaction name="action_Centers"/>
+    <addaction name="action_Corners"/>
+    <addaction name="action_Xlow"/>
+    <addaction name="action_Ylow"/>
+    <addaction name="action_Edges"/>
+    <addaction name="action_Legend"/>
+   </widget>
    <addaction name="menu_File"/>
    <addaction name="menu_Mesh"/>
+   <addaction name="menu_View"/>
    <addaction name="menu_Help"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
@@ -335,6 +349,113 @@
    </property>
    <property name="toolTip">
     <string>Regrid non-orthogonal mesh</string>
+   </property>
+  </action>
+
+  <action name="action_Flux">
+   <property name="text">
+    <string>Poloidal flux</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="toolTip">
+    <string>Plot poloidal flux?</string>
+   </property>
+  </action>
+  <action name="action_Wall">
+   <property name="text">
+    <string>Wall</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="toolTip">
+    <string>Plot wall?</string>
+   </property>
+  </action>
+  <action name="action_Centers">
+   <property name="text">
+    <string>Cell centers</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="toolTip">
+    <string>Plot cell centers?</string>
+   </property>
+  </action>
+  <action name="action_Corners">
+   <property name="text">
+    <string>Cell corners</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="toolTip">
+    <string>Plot cell corners?</string>
+   </property>
+  </action>
+  <action name="action_Xlow">
+   <property name="text">
+    <string>Cell Xlow</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="toolTip">
+    <string>Plot cell Xlow locations?</string>
+   </property>
+  </action>
+  <action name="action_Ylow">
+   <property name="text">
+    <string>Cell Ylow</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="toolTip">
+    <string>Plot cell Ylow locations?</string>
+   </property>
+  </action>
+  <action name="action_Edges">
+   <property name="text">
+    <string>Cell edges</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="toolTip">
+    <string>Plot cell edges?</string>
+   </property>
+  </action>
+  <action name="action_Legend">
+   <property name="text">
+    <string>Legend</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="toolTip">
+    <string>Plot legend?</string>
    </property>
   </action>
  </widget>

--- a/hypnotoad/gui/matplotlib_widget.py
+++ b/hypnotoad/gui/matplotlib_widget.py
@@ -44,7 +44,7 @@ class MatplotlibWidget:
         if keep_limits:
             # slightly hacky way to clear axes, but prevents axis limits being reset when
             # we redraw
-            for artist in self.axes.lines + self.axes.collections:
+            for artist in self.axes.lines + self.axes.collections + self.axes.patches:
                 artist.remove()
             self.axes.set_prop_cycle(None)
             return

--- a/hypnotoad/utils/critical.py
+++ b/hypnotoad/utils/critical.py
@@ -20,7 +20,6 @@ along with FreeGS.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 
-
 from scipy import interpolate
 from numpy.linalg import inv
 from numpy import (

--- a/integrated_tests/utils.py
+++ b/integrated_tests/utils.py
@@ -17,6 +17,10 @@ expected_different_vars = [
     "hypnotoad_inputs_yaml",
     "Python_version",
     "module_versions",
+    # Variables that have been added
+    "penalty_mask",
+    "closed_wall_R",
+    "closed_wall_Z",
 ]
 
 

--- a/integrated_tests/utils.py
+++ b/integrated_tests/utils.py
@@ -17,7 +17,8 @@ expected_different_vars = [
     "hypnotoad_inputs_yaml",
     "Python_version",
     "module_versions",
-    # Variables that have been added
+    # Variables that have been added. These entries can be removed if/when the
+    # expected output is re-generated.
     "penalty_mask",
     "closed_wall_R",
     "closed_wall_Z",


### PR DESCRIPTION
Updates the gui options, and triggers a replotting of the grid.

Some plotting settings are in the Preferences dialog. The View menu and preferences dialog are now kept in sync.

Fixed the plot_grid keep_limits functionality, so that the xlim and ylim settings are preserved when replotting.

- [x] Updated manual
- [x] Updated `doc/whats-new.md` with a summary of the changes
