### PR TITLE
Save Jpar0 to output tokamak grids

### DIFF
--- a/hypnotoad/cases/tokamak.py
+++ b/hypnotoad/cases/tokamak.py
@@ -317,6 +317,8 @@ class TokamakEquilibrium(Equilibrium):
         psi1D,
         fpol1D,
         pressure=None,
+        fprime=None,
+        pprime=None,
         wall=None,
         psi_axis_gfile=None,
         psi_bdry_gfile=None,
@@ -340,6 +342,8 @@ class TokamakEquilibrium(Equilibrium):
         --------
 
         pressure[nf] = 1D array of pressure as a function of psi1D [Pa]
+        fprime[nf] = 1D array of df / dpsi
+        pprime[nf] = 1D array of dp / dpsi . If set then pressure must also be set.
 
         wall = [(R0,Z0), (R1, Z1), ...]
                A list of coordinate pairs, defining the vessel wall.
@@ -361,6 +365,9 @@ class TokamakEquilibrium(Equilibrium):
                options (self.nonorthogonal_options)
 
         """
+
+        if pprime is not None:
+            assert pressure is not None
 
         self.user_options = self.user_options_factory.create(settings)
 
@@ -409,12 +416,22 @@ class TokamakEquilibrium(Equilibrium):
                 # fpol constant in SOL
                 fpol1D = np.concatenate([fpol1D, np.full(psiSOL.shape, fpol1D[-1])])
 
+                if fprime is not None:
+                    fprime = np.concatenate([fprime, np.full(psiSOL.shape, 0.0)])
+
             if pressure is not None:
                 # Use an exponential decay for the pressure, based on
                 # the value and gradient at the plasma edge
                 p0 = pressure[-1]
                 # p = p0 * exp( (psi - psi0) * dpdpsi / p0)
-                pressure = np.concatenate([pressure, p0 * np.exp(psiSOL * dpdpsi / p0)])
+                pressure = np.concatenate(
+                    [pressure, p0 * np.exp((psiSOL - psi1D[-1]) * dpdpsi / p0)]
+                )
+
+                if pprime is not None:
+                    pprime = np.concatenate(
+                        [pprime, dpdpsi * np.exp((psiSOL - psi1D[-1]) * dpdpsi / p0)]
+                    )
 
         self.magneticFunctionsFromGrid(
             R1D, Z1D, psi2D, self.user_options.psi_interpolation_method
@@ -434,7 +451,12 @@ class TokamakEquilibrium(Equilibrium):
             # ext=3 specifies that boundary values are used outside range
 
             # Spline representing the derivative of f
-            self.fprime_spl = self.f_spl.derivative()
+            if fprime is not None:
+                self.fprime_spl = interpolate.InterpolatedUnivariateSpline(
+                    psi1D * self.f_psi_sign, fprime, ext=3
+                )
+            else:
+                self.fprime_spl = self.f_spl.derivative()
         else:
             self.f_spl = lambda psi: 0.0
             self.fprime_spl = lambda psi: 0.0
@@ -444,9 +466,17 @@ class TokamakEquilibrium(Equilibrium):
             self.p_spl = interpolate.InterpolatedUnivariateSpline(
                 psi1D * self.f_psi_sign, pressure, ext=3
             )
+
+            if pprime is not None:
+                self.pprime_spl = interpolate.InterpolatedUnivariateSpline(
+                    psi1D * self.f_psi_sign, pprime, ext=3
+                )
+            else:
+                self.pprime_spl = self.p_spl.derivative()
         else:
             # If no pressure, then not output to grid file
             self.p_spl = None
+            self.pprime_spl = None
 
         # Find critical points (O- and X-points)
         R2D, Z2D = np.meshgrid(R1D, Z1D, indexing="ij")
@@ -1621,9 +1651,14 @@ class TokamakEquilibrium(Equilibrium):
                     eqreg.pressure = lambda psi: self.pressure(
                         leg_psi + sign * abs(psi - leg_psi)
                     )
+                    # Set pprime and fprime to zero so Jpar0 = 0
+                    eqreg.pprime = lambda psi: 0.0
+                    eqreg.fprime = lambda psi: 0.0
                 else:
-                    # Core region, so use the core pressure
+                    # Core region, so use the core profiles
                     eqreg.pressure = self.pressure
+                    eqreg.pprime = self.pprime
+                    eqreg.fprime = self.fpolprime
 
             region_objects[name] = eqreg
         # The region objects need to be sorted, so that the
@@ -1677,8 +1712,12 @@ class TokamakEquilibrium(Equilibrium):
 
     @Equilibrium.handleMultiLocationArray
     def fpolprime(self, psi):
-        """psi-derivative of fpol"""
-        return self.fprime_spl(psi * self.f_psi_sign)
+        """psi-derivative of fpol
+        Note: Zero outside core."""
+        fprime = self.fprime_spl(psi * self.f_psi_sign)
+        psinorm = (psi - self.psi_axis) / (self.psi_bdry - self.psi_axis)
+        fprime[psinorm > 1.0] = 0.0
+        return fprime
 
     @Equilibrium.handleMultiLocationArray
     def pressure(self, psi):
@@ -1686,6 +1725,17 @@ class TokamakEquilibrium(Equilibrium):
         if self.p_spl is None:
             return None
         return self.p_spl(psi * self.f_psi_sign)
+
+    @Equilibrium.handleMultiLocationArray
+    def pprime(self, psi):
+        """psi-derivative of plasma pressure
+        Note: Zero outside the core"""
+        if self.pprime_spl is None:
+            return None
+        pprime = self.pprime_spl(psi * self.f_psi_sign)
+        psinorm = (psi - self.psi_axis) / (self.psi_bdry - self.psi_axis)
+        pprime[psinorm > 1.0] = 0.0
+        return pprime
 
     @property
     def Bt_axis(self):
@@ -1751,6 +1801,8 @@ def read_geqdsk(
 
     pressure = data["pres"]
     fpol = data["fpol"]
+    fprime = data["ffprime"] / fpol
+    pprime = data["pprime"]
 
     result = TokamakEquilibrium(
         R1D,
@@ -1761,6 +1813,8 @@ def read_geqdsk(
         psi_bdry_gfile=psi_bdry_gfile,
         psi_axis_gfile=psi_axis_gfile,
         pressure=pressure,
+        fprime=fprime,
+        pprime=pprime,
         wall=wall,
         make_regions=make_regions,
         settings=settings,

--- a/hypnotoad/core/mesh.py
+++ b/hypnotoad/core/mesh.py
@@ -902,6 +902,25 @@ class MeshRegion:
 
         self.Bxy = numpy.sqrt(self.Bpxy**2 + self.Btxy**2)
 
+        if hasattr(
+            self.meshParent.equilibrium.regions[self.equilibriumRegion.name], "pprime"
+        ) and hasattr(
+            self.meshParent.equilibrium.regions[self.equilibriumRegion.name], "fprime"
+        ):
+            # Calculate parallel current density from p' and f'
+
+            pprime = self.meshParent.equilibrium.regions[
+                self.equilibriumRegion.name
+            ].pprime(self.psixy)
+            fprime = self.meshParent.equilibrium.regions[
+                self.equilibriumRegion.name
+            ].fprime(self.psixy)
+
+            mu0 = 4e-7 * numpy.pi
+            self.Jpar0 = (
+                self.Bxy * fprime / mu0 + self.Rxy * self.Btxy * pprime / self.Bxy
+            )
+
     def geometry2(self):
         """
         Continuation of geometry1(), but needs neighbours to have calculated Bp so called
@@ -3657,8 +3676,11 @@ class BoutMesh(Mesh):
         addFromRegions("bxcvy")
         addFromRegions("bxcvz")
 
-        if hasattr(next(iter(self.equilibrium.regions.values())), "pressure"):
+        if hasattr(next(iter(self.regions.values())), "pressure"):
             addFromRegions("pressure")
+
+        if hasattr(next(iter(self.regions.values())), "Jpar0"):
+            addFromRegions("Jpar0")
 
         # Penalty mask
         self.penalty_mask = BoutArray(

--- a/hypnotoad/geqdsk/_geqdsk.py
+++ b/hypnotoad/geqdsk/_geqdsk.py
@@ -195,6 +195,8 @@ def read(fh, cocos=1):
 
       fpol          1D array of f(psi)=R*Bt  [meter-Tesla]
       pres          1D array of p(psi) [Pascals]
+      ffprime       1D array of ff'(psi)
+      pprime        1D array of p'(psi)
       qpsi          1D array of q(psi)
 
       psi           2D array (nx,ny) of poloidal flux


### PR DESCRIPTION
Reads ffprime, pprime from geqdsk file; passes through to regions, calculates Jpar0, and saves to the output grid.

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Udated manual
- [ ] Updated `doc/whats-new.md` with a summary of the changes
