### PR TITLE
GUI: Remember the path to the input files

### DIFF
--- a/hypnotoad/gui/gui.py
+++ b/hypnotoad/gui/gui.py
@@ -80,6 +80,9 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         super().__init__(None)
         self.setupUi(self)
 
+        # Used in file dialogs
+        self._current_dir = "."
+
         try:
             self.menu_File.setToolTipsVisible(True)
             self.menu_Mesh.setToolTipsVisible(True)
@@ -452,7 +455,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         """Choose a Hypnotoad options file to load"""
 
         filename, _ = QFileDialog.getOpenFileName(
-            self, "Open options file", ".", filter=YAML_FILTER
+            self, "Open options file", self._current_dir, filter=YAML_FILTER
         )
 
         if (filename is None) or (filename == ""):
@@ -460,6 +463,9 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         if not os.path.exists(filename):
             self.write("Could not find " + filename)
             return
+
+        # Record the directory so user doesn't have to navigate again
+        self._current_dir = os.path.dirname(filename)
 
         self.options_file_line_edit.setText(filename)
         self.filename = filename
@@ -506,7 +512,9 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
     def select_geqdsk_file(self):
         """Choose a "geqdsk" equilibrium file to open"""
 
-        filename, _ = QFileDialog.getOpenFileName(self, "Open geqdsk file", ".")
+        filename, _ = QFileDialog.getOpenFileName(
+            self, "Open geqdsk file", self._current_dir
+        )
 
         if (filename is None) or (filename == ""):
             return  # Cancelled
@@ -516,6 +524,9 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
                 f"QLineEdit {{ background-color: {COLOURS['red']} }}"
             )
             return
+
+        # Record the directory so user doesn't have to navigate again
+        self._current_dir = os.path.dirname(filename)
 
         self.geqdsk_file_line_edit.setText(filename)
         self.geqdsk_file_line_edit.setStyleSheet("")
@@ -643,7 +654,7 @@ class HypnotoadGui(QMainWindow, Ui_Hypnotoad):
         filename, _ = QFileDialog.getSaveFileName(
             self,
             "Save grid to file",
-            self.gui_options["grid_file"],
+            os.path.join(self._current_dir, self.gui_options["grid_file"]),
             filter=NETCDF_FILTER,
         )
 


### PR DESCRIPTION
When a user navigates to a directory to read the YML file, then wants to open a geqdsk file, start in the same directory.

<!--
Please run flake8 and black on your changes, these will be checked by the CI.
Feel free to remove any of the check-list items that aren't relevant to your PR.
-->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Udated manual
- [ ] Updated `doc/whats-new.md` with a summary of the changes
