### PR TITLE
More frequent scheduled CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,7 +7,7 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: '25 1 3 * *'
+    - cron: '25 1 * * 3'
 
 concurrency:
   group: ${{ github.workflow}}-${{ github.ref }}


### PR DESCRIPTION
As scheduled CI runs are cancelled after 3 months by Github, useful to run more frequently (once a week rather than once a month) to have a more recent CI run when the scheduled runs do get cancelled.
